### PR TITLE
Add Action For Caching Hub Dependencies

### DIFF
--- a/.github/workflows/cache-hubval-deps.yaml
+++ b/.github/workflows/cache-hubval-deps.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - name: "Checkout code"
+      - name: "Checkout Code"
         uses: actions/checkout@v4
 
       - name: "Setup R"
@@ -29,7 +29,7 @@ jobs:
         run: |
           sudo apt-get update
 
-      - name: "Set up R dependencies"
+      - name: "Set Up R Dependencies"
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           packages: |

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install
+      - name: "Install"
         uses: posit-dev/setup-air@v1
 
-      - name: Check
+      - name: "Check"
         run: air format . --check

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -42,18 +42,18 @@ jobs:
             any::hubAdmin
             any::sessioninfo
 
-      - name: Run Validations
+      - name: "Run Validations"
         id: validate
         run: hubAdmin::ci_validate_hub_config(diff = "${{ runner.temp }}/diff.md")
         shell: Rscript {0}
-      - name: Comment On PR
+      - name: "Comment On PR"
         id: comment-diff
         if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: carpentries/actions/comment-diff@main
         with:
           pr: ${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}/diff.md
-      - name: Error On Failure
+      - name: "Error On Failure"
         if: ${{ steps.validate.outputs.result == 'false' }}
         run: |
           echo "::error title=Invalid Configuration::Errors were detected in one or more config files in 'hub-config/'"

--- a/.github/workflows/validate-submission.yaml
+++ b/.github/workflows/validate-submission.yaml
@@ -20,7 +20,7 @@ jobs:
           use-public-rspm: true
           extra-repositories: 'https://hubverse-org.r-universe.dev'
 
-      - name: Update R
+      - name: "Update R"
         run: |
           sudo apt-get update
 
@@ -50,7 +50,7 @@ jobs:
       # skip_submit_window_check = Sys.getenv("model") == "ensemble"
       # # was removed from after pr_number line
 
-      - name: Run Validations
+      - name: "Run Validations"
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |


### PR DESCRIPTION
Please see issue #27 for more details.

This PR:

* [x] Adds a GitHub actions workflow file called `cache-hubval-deps` that builds a dependency cache. This file was copied from <https://github.com/CDCgov/covid19-forecast-hub/blob/main/.github/workflows/cache-hubval-deps.yaml> and was slightly, non-programmatically modified from the original.