### PR TITLE
Add Actions For Creating Ensemble And Baseline Models

### DIFF
--- a/.github/workflows/create-baseline.yaml
+++ b/.github/workflows/create-baseline.yaml
@@ -1,0 +1,67 @@
+name: "RSV Hub Baseline Model"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 20 * * 3"
+
+jobs:
+  generate-baseline-forecasts:
+    if: ${{ github.repository_owner == 'CDCgov' }}
+    runs-on: ubuntu-22.04
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - name: "Generate Installation Token"
+      id: get_token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ vars.GH_APP_ID }}
+        private-key: ${{ secrets.GH_APP_KEY }}
+    - name: "Checkout Code"
+      uses: actions/checkout@v4
+    - name: "Setup R"
+      uses: r-lib/actions/setup-r@v2
+      with:
+        install-r: false
+        use-public-rspm: true
+    - name: "Set Up R Dependencies"
+      uses: r-lib/actions/setup-r-dependencies@v2
+      with:
+        pak-version: "devel"
+        packages: |
+          any::lubridate
+          any::dplyr
+          any::tidyselect
+          any::stringr
+          any::glue
+          any::readr
+          any::fs
+          any::cli
+          any::tidyr
+          any::checkmate
+          any::withr
+          any::hardhat
+          github::cmu-delphi/epiprocess
+          github::cmu-delphi/epipredict
+          github::cdcgov/forecasttools
+          github::hubverse-org/hubData
+          github::cdcgov/hubhelpr
+    - name: "Generate Baseline"
+      run: |
+        REF_DATE=$(Rscript -e "cat(strftime(lubridate::ceiling_date(lubridate::today(), 'week', week_start = 6, change_on_boundary = FALSE)))")
+        Rscript -e "hubhelpr::generate_hub_baseline('.', '$REF_DATE', 'rsv')"
+    - name: "Set Date"
+      run: echo "DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+    - name: "Commit Changes"
+      uses: EndBug/add-and-commit@v9
+      with:
+        message: "Add RSV baseline forecasts"
+        default_author: github_actions
+        push: true
+        new_branch: add-rsv-baseline-${{ env.DATE }}
+    - name: "Create Pull Request"
+      id: create_pr
+      run: |
+        gh pr create --base main --head add-rsv-baseline-${{ env.DATE }} --title "Add RSV baseline forecast" --body "This PR is generated automatically."
+      env:
+        GH_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
For the full scope of this PR, please refer to issue #56 .

Specifically, this PR:

* [x] Adds a modified version of <https://github.com/CDCgov/covid19-forecast-hub/blob/main/.github/workflows/create-baseline.yaml>, which uses `hubhelpr`, has dates in the branch names, and applies not to COVID-19 but to RSV instead.