### PR TITLE
Use Pre-Commit Continuous Integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,13 @@
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ""
+    autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
This PR:

* [x] Updates the `.pre-commit-config.yaml` file with a section for the `pre-commit` CI settings.
* [x] Configures `pre-commit` CI to have access to `rsv-forecast-hub` (as the repository is now public; also, notice the CI working below).