### PR TITLE
Onboard rsv-forecast-hub to AWS/S3

### DIFF
--- a/.github/workflows/hubverse-aws-upload.yaml
+++ b/.github/workflows/hubverse-aws-upload.yaml
@@ -1,0 +1,82 @@
+name: Upload hub data to a hubverse-hosted AWS S3 bucket
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  # Hubverse AWS account number
+  AWS_ACCOUNT: 767397675902
+
+permissions:
+  contents: read
+  # id-token write required for AWS auth
+  id-token: write
+
+jobs:
+  upload:
+    # Don't run on forked repositories
+    if: github.event.repository.fork != true
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Get hub cloud config
+        # save cloud-related fields from admin config as environment variables
+        # (jq json parser is installed on Github-hosted runners)
+        run: |
+          cloud_enabled=$(cat ./hub-config/admin.json | jq -r '.cloud.enabled') \
+            && echo "CLOUD_ENABLED=$cloud_enabled"
+          cloud_storage_location=$(cat ./hub-config/admin.json | jq -r '.cloud.host.storage_location') \
+            && echo "CLOUD_STORAGE_LOCATION=$cloud_storage_location"
+          echo "CLOUD_ENABLED=$cloud_enabled" >> $GITHUB_ENV
+          echo "CLOUD_STORAGE_LOCATION=$cloud_storage_location" >> $GITHUB_ENV
+
+      - name: Configure AWS credentials
+        # request credentials to assume the hub's AWS role via OpenID Connect
+        if: env.CLOUD_ENABLED == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT }}:role/${{ env.CLOUD_STORAGE_LOCATION }}
+          aws-region: us-east-1
+
+      - name: Install rclone
+        if: env.CLOUD_ENABLED == 'true'
+        run: |
+          # debian version of rclone is outdated and will result in config name errors
+          # https://github.com/rclone/rclone/issues/6060
+          curl https://rclone.org/install.sh | sudo bash
+          rclone version
+
+      - name: Sync files to cloud storage
+        # sync specified hub directories to S3
+        # (to exclude a directory, remove it from the hub_directories list below)
+        if: env.CLOUD_ENABLED == 'true'
+        run: |
+          hub_directories=(
+            'auxiliary-data'
+            'hub-config'
+            'model-abstracts'
+            'model-metadata'
+            'target-data'
+          )
+          for DIRECTORY in "${hub_directories[@]}"
+          do
+            if [ -d "./$DIRECTORY" ]
+            then
+              rclone sync \
+                "./$DIRECTORY/" \
+                ":s3,provider=AWS,env_auth:$BUCKET_NAME/$DIRECTORY" \
+                --checksum --verbose --stats-one-line --config=/dev/null
+            fi
+          done
+          # unlike other data, model-outputs are synced to a "raw" location
+          # so we can transform it before presenting to users
+          rclone sync ./model-output/ ":s3,provider=AWS,env_auth:$BUCKET_NAME/raw/model-output" \
+            --checksum --verbose --stats-one-line --config=/dev/null
+        shell: bash
+        env:
+          BUCKET_NAME: ${{ env.CLOUD_STORAGE_LOCATION }}

--- a/.github/workflows/hubverse-aws-upload.yaml
+++ b/.github/workflows/hubverse-aws-upload.yaml
@@ -1,4 +1,4 @@
-name: Upload hub data to a hubverse-hosted AWS S3 bucket
+name: "Upload Hub Data To Hubverse Hosted AWS S3 Bucket"
 
 on:
   push:

--- a/.github/workflows/hubverse-aws-upload.yaml
+++ b/.github/workflows/hubverse-aws-upload.yaml
@@ -16,15 +16,15 @@ permissions:
 
 jobs:
   upload:
-    # Don't run on forked repositories
+    # don't run on forked repositories
     if: github.event.repository.fork != true
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Checkout
+      - name: "Checkout"
         uses: actions/checkout@v5
 
-      - name: Get hub cloud config
+      - name: "Get Hub Cloud Config"
         # save cloud-related fields from admin config as environment variables
         # (jq json parser is installed on Github-hosted runners)
         run: |
@@ -35,7 +35,7 @@ jobs:
           echo "CLOUD_ENABLED=$cloud_enabled" >> $GITHUB_ENV
           echo "CLOUD_STORAGE_LOCATION=$cloud_storage_location" >> $GITHUB_ENV
 
-      - name: Configure AWS credentials
+      - name: "Configure AWS Credentials"
         # request credentials to assume the hub's AWS role via OpenID Connect
         if: env.CLOUD_ENABLED == 'true'
         uses: aws-actions/configure-aws-credentials@v4
@@ -43,7 +43,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT }}:role/${{ env.CLOUD_STORAGE_LOCATION }}
           aws-region: us-east-1
 
-      - name: Install rclone
+      - name: "Install rclone"
         if: env.CLOUD_ENABLED == 'true'
         run: |
           # debian version of rclone is outdated and will result in config name errors
@@ -51,7 +51,7 @@ jobs:
           curl https://rclone.org/install.sh | sudo bash
           rclone version
 
-      - name: Sync files to cloud storage
+      - name: "Sync Files To Cloud Storage"
         # sync specified hub directories to S3
         # (to exclude a directory, remove it from the hub_directories list below)
         if: env.CLOUD_ENABLED == 'true'

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ preferred tools. The options include:
 | Access Method              | Description                                                                           |
 | -------------------------- | ------------------------------------------------------------------------------------- |
 | hubData (R)                | Hubverse R client and R code for accessing hub data.                                  |
-| Pyarrow (Python)           | Python open-source library for data manipulation.                                     |
+| hub-data (Python)          | Python package for working with hubverse data                                         |
 | AWS command line interface | Download data and use hubData, Pyarrow, or another tool for fast local access.        |
 
 In general, accessing the data directly from S3 (instead of downloading it first) is more convenient. However, if performance is critical (for example, you're building an interactive visualization), or if you need to work offline,
@@ -188,103 +188,22 @@ hub_con %>%
 
 <details markdown=1>
 
-<summary>Pyarrow (Python)</summary>
+<summary>hub-data (Python)</summary>
 
-Python users can use [Pyarrow](https://arrow.apache.org/docs/python/index.html) to work with hub data in S3.
+The Hubverse team is developing a Python client which provides some initial tools for accessing Hubverse data. The repository is located at https://github.com/hubverse-org/hub-data .
 
-Pandas users can access hub data as described below and then use the `to_pandas()` method to get a Pandas dataframe.
 
-Pyarrow is a good choice if you:
+### Installing hub-data
 
-- already use Python for data analysis
-- want to interactively explore hub data from the cloud without downloading it
-- want to save a subset of the hub's data (*e.g.*, forecasts for a specific date or target) to your local machine
-- want to save hub data in a different file format (*e.g.*, `.parquet` to `.csv`)
-
-### Installing Pyarrow
-
-Use `pip` to install Pyarrow:
+Use pip to install hub-data (the pypi package is https://pypi.org/project/hubdata ):
 
 ```sh
-python -m pip install pyarrow
+pip install hubdata
 ```
 
-### Using Pyarrow
+### Using hub-data
 
-The examples below start by creating a Pyarrow dataset that references the hub files on S3.
-
-
-#### Accessing Model Output Data
-
-Get all model-output files. This example creates an in-memory [Pyarrow table](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html) with all model-output files from the hub (it will take a few minutes to run).
-
-```python
-import pyarrow.dataset as ds
-import pyarrow.fs as fs
-
-
-# define an S3 filesystem with anonymous access (no credentials required)
-s3 = fs.S3FileSystem(access_key=None, secret_key=None, anonymous=True)
-
-# create a Pyarrow dataset that references the hub's model-output files
-# and convert it to an in-memory Pyarrow table
-mo = ds.dataset("rsv-forecast-hub/model-output/", filesystem=s3, format="parquet").to_table()
-
-# to convert the Pyarrow table to a Pandas dataframe:
-df = mo.to_pandas()
-```
-
-Get the model-output files for a specific team (all rounds).
-
-```python
-import pandas as pd
-import pyarrow.dataset as ds
-import pyarrow.fs as fs
-
-
-# define an S3 filesystem with anonymous access (no credentials required)
-s3 = fs.S3FileSystem(access_key=None, secret_key=None, anonymous=True)
-
-# create a Pyarrow dataset that references a team's model-output files
-# and convert it to an in-memory Pyarrow table
-mo = ds.dataset("rsv-forecast-hub/model-output/pending.../", filesystem=s3, format="parquet").to_table()
-
-# to convert the Pyarrow table to a Pandas dataframe:
-df = mo.to_pandas()
-df.head()
-
-# pending...
-```
-
-- [Full documentation of Pyarrow table API](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html)
-
-Add a filter to model output data before converting it to a Pyarrow table. Filters are expressed as a [Pyarrow dataset Expression](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Expression.html#pyarrow.dataset.Expression).
-
-```python
-from datetime import datetime
-import pandas as pd
-import pyarrow as pa
-import pyarrow.compute as pc
-import pyarrow.dataset as ds
-import pyarrow.fs as fs
-
-
-# define an S3 filesystem with anonymous access (no credentials required)
-s3 = fs.S3FileSystem(access_key=None, secret_key=None, anonymous=True)
-
-# create a Pyarrow dataset that references a team's model-output files, apply filters,
-# and convert it to an in-memory Pyarrow table
-mo = ds.dataset("rsv-forecast-hub/model-output/", filesystem=s3, format="parquet").to_table(
-  filter=(
-    pc.field("target") == "wk inc rsv hosp") &
-    pc.equal(pc.field("reference_date"), pa.scalar(datetime(2023, 10, 14), type=pa.date32())))
-
-# to convert the Pyarrow table to a Pandas dataframe:
-df = mo.to_pandas()
-df.head()
-
-# pending...
-```
+Please see the [hub-data package documentation](https://hubverse-org.github.io/hub-data) for examples of how to use the CLI, and the `hubdata.connect_hub()` and `hubdata.create_hub_schema()` functions.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -190,15 +190,17 @@ hub_con %>%
 
 <summary>hub-data (Python)</summary>
 
-The Hubverse team is developing a Python client which provides some initial tools for accessing Hubverse data. The repository is located at https://github.com/hubverse-org/hub-data .
+The Hubverse team is developing a Python client which provides some initial tools for accessing Hubverse data. The repository is located at <https://github.com/hubverse-org/hub-data>.
 
 
 ### Installing hub-data
 
-Use pip to install hub-data (the pypi package is https://pypi.org/project/hubdata ):
+Use `pip` to install `hub-data` (the `pypi` package is <https://pypi.org/project/hubdata>):
 
 ```sh
-pip install hubdata
+
+`pip install hubdata`
+
 ```
 
 ### Using hub-data

--- a/hub-config/admin.json
+++ b/hub-config/admin.json
@@ -8,8 +8,8 @@
   },
   "repository": {
     "host": "github",
-    "owner": "cdcent",
-    "name": "cfa-internal-rsv-forecast-hub"
+    "owner": "CDCgov",
+    "name": "rsv-forecast-hub"
   },
   "file_format": [
     "csv",

--- a/hub-config/admin.json
+++ b/hub-config/admin.json
@@ -21,7 +21,7 @@
     "host": {
       "name": "aws",
       "storage_service": "s3",
-      "storage_location": "cfa-internal-rsv-forecast-hub"
+      "storage_location": "rsv-forecast-hub"
     }
   }
 }


### PR DESCRIPTION
This PR proposes three edits required to enable cloud-based data access.

1. **hub-config/admin.json**: edited "repository" and "cloud" sections
2. **.github/workflows/hubverse-aws-upload.yaml**: copied from: https://github.com/hubverse-org/hubverse-actions/blob/main/hubverse-aws-upload/hubverse-aws-upload.yaml
3. **README.md**: updated Python section of "Accessing RSV Data On The Cloud" to use new https://github.com/hubverse-org/hub-data package