### PR TITLE
Ignore model-output and nssp-raw-data in detect secrets hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     # detect-secrets scan > .secrets.baseline
     -   id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
-        exclude: package.lock.json
+        exclude: "package.lock.json|model-output/.*|nssp-data-raw/.*"
 -   repo: https://github.com/crate-ci/typos
     rev: v1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
     # detect-secrets scan > .secrets.baseline
     -   id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
-        exclude: "package.lock.json|model-output/.*|nssp-data-raw/.*"
+        exclude: "package.lock.json|model-output/.*|auxiliary-data/nssp-raw-data/.*"
 -   repo: https://github.com/crate-ci/typos
     rev: v1
     hooks:

--- a/_typos.toml
+++ b/_typos.toml
@@ -36,4 +36,5 @@ extend-exclude = [
     "*.css",
     "*.ipynb",
     "*.json",
+    "*.csv",
 ]


### PR DESCRIPTION
This PR:

* [x] Updates the `detect-secrets` hook in `.pre-commit-config.yaml` to ignore `model-output` and `nssp-data-raw`.