### PR TITLE
fix "get PR" step in `auto-merge-pr.yaml`

### DIFF
--- a/.github/workflows/auto-merge-pr.yaml
+++ b/.github/workflows/auto-merge-pr.yaml
@@ -22,32 +22,36 @@ jobs:
           private-key: ${{ secrets.CDCGOV_HUB_BOT_APP_KEY }}
 
       - name: "Get PR Number"
-        id: get_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_TARGET_REPO: ${{ github.repository }}
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
         run: |
-          PR_NUMBER=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}" | \
-            jq -r '.pull_requests[0].number // empty')
-
+          PR_NUMBER=$(gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" \
+            --json number \
+            --jq '.number')
           if [ -z "$PR_NUMBER" ]; then
-            echo "No PR associated with this workflow run"
+            echo "Error: PR_NUMBER is empty"
             exit 1
           fi
-
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "Found PR #$PR_NUMBER"
+          echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
+          echo "PR number from workflow_run event: ${PR_NUMBER}"
 
       - name: "Approve PR"
         env:
           GH_TOKEN: ${{ steps.get_token.outputs.token }}
         run: |
-          gh pr review ${{ steps.get_pr.outputs.pr_number }} --approve \
+          gh pr review $PR_NUMBER --approve \
             --body "Changes approved. Thank you for your contribution."
 
       - name: "Merge PR"
         env:
           GH_TOKEN: ${{ steps.get_token.outputs.token }}
         run: |
-          gh pr merge ${{ steps.get_pr.outputs.pr_number }} --squash \
-            --body "PR #${{ steps.get_pr.outputs.pr_number }} was automatically merged because the user is authorized to modify these directories."
-
-          echo "PR #${{ steps.get_pr.outputs.pr_number }} has been automatically merged"
+          gh pr merge --auto $PR_NUMBER --squash \
+            --body "PR #${PR_NUMBER} was automatically merged because the user is authorized to modify these directories."

--- a/.github/workflows/auto-merge-pr.yaml
+++ b/.github/workflows/auto-merge-pr.yaml
@@ -36,7 +36,7 @@ jobs:
             --json number \
             --jq '.number')
           if [ -z "$PR_NUMBER" ]; then
-            echo "Error: PR_NUMBER is empty"
+            echo "No PR associated with this workflow run"
             exit 1
           fi
           echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV


### PR DESCRIPTION
Modifies "Get PR Number" step to mirror what current set up in [covidhub](https://github.com/CDCgov/covid19-forecast-hub/blob/752c21f2ecf0addf5bd3da01f4d9fa15f2a26e80/.github/workflows/merge-pr.yaml#L24)