### PR TITLE
Update Typos Hook To Latest Version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
         args: ["--baseline", ".secrets.baseline"]
         exclude: "package.lock.json|^model-output/.*\\.(csv|parquet)$|^target-data/.*\\.(csv|parquet)$|^auxiliary-data/nssp-raw-data/.*\\.(csv|parquet)$"
 -   repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.39.1
     hooks:
     -   id: typos
         args: ["--force-exclude"]


### PR DESCRIPTION
For whatever reason, several STF repositories have `rev: v1` for the `repo: https://github.com/crate-ci/typos` hook — something that probably persisted over time via copying and pasting and that produces the following warning, which the author has found is NOT alleviated by following the Warning's suggested action.

> [WARNING] The 'rev' field of repo 'https://github.com/crate-ci/typos' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.

The current version of `typos` is `v1.39.1` (see <https://github.com/crate-ci/typos>). This PR:

* [x] Updates the version of `typos` in this repository from `v1` to the latest version, i.e. `v1.39.1`; now no warning is produced when running `pre-commit run --all-files`.