### PR TITLE
Update Authorization Workflow And Exclusions

### DIFF
--- a/.github/workflows/check_authorized_users.yaml
+++ b/.github/workflows/check_authorized_users.yaml
@@ -7,8 +7,8 @@ on:
     paths:
       - "model-output/**"
       - "!model-output/README.md"
-      - "!model-output/CovidHub-ensemble/**"
-      - "!model-output/CovidHub-baseline/**"
+      - "!model-output/RSVHub-ensemble/**"
+      - "!model-output/RSVHub-baseline/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
This PR was created to address <https://github.com/CDCgov/rsv-forecast-hub/actions/runs/19546210420/job/55965533032> and also update `check_authorized_users.yaml` in `.github/workflows` to ignore `model-output` changes for the `RSVHub-ensemble` instead of `CovidHub-ensemble` (missed).

This PR:

* [x] Updates `CovidHub` &rarr; `RSVHub` in `.github/workflows/check_authorized_users.yaml`.
* [x] Verifies no additional instances of `COVID` or `Covid` where RSV should occur using `Cmd-Shift-F` on entire repository.