### PR TITLE
Add Baseline Hub Forecast For 2025-11-22

### DIFF
--- a/model-output/RSVHub-baseline/2025-11-22-RSVHub-baseline.csv
+++ b/model-output/RSVHub-baseline/2025-11-22-RSVHub-baseline.csv
@@ -1,0 +1,11961 @@
+reference_date,horizon,target,target_end_date,location,output_type,output_type_id,value
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.01,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.025,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.05,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.1,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.15,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.2,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.25,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.3,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.35,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.4,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.45,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.5,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.55,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.6,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.65,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.7,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.75,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.8,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.85,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.9,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.95,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.975,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,01,quantile,0.99,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.01,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.025,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.05,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.1,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.15,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.2,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.25,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.3,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.35,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.4,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.45,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.5,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.55,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.6,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.65,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.7,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.75,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.8,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.85,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.9,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.95,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.975,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,02,quantile,0.99,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.01,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.025,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.05,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.1,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.15,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.2,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.25,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.3,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.35,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.4,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.45,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.5,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.55,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.6,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.65,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.7,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.75,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.8,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.85,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.9,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.95,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.975,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,04,quantile,0.99,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.01,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.025,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.05,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.1,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.15,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.2,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.25,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.3,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.35,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.4,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.45,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.5,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.55,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.6,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.65,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.7,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.75,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.8,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.85,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.9,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.95,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.975,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,05,quantile,0.99,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.01,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.025,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.05,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.1,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.15,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.2,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.25,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.3,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.35,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.4,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.45,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.5,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.55,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.6,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.65,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.7,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.75,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.8,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.85,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.9,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.95,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.975,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,06,quantile,0.99,65
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.01,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.025,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.05,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.1,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.15,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.2,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.25,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.3,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.35,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.4,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.45,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.5,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.55,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.6,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.65,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.7,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.75,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.8,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.85,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.9,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.95,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.975,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,08,quantile,0.99,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.01,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.025,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.05,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.1,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.15,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.2,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.25,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.3,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.35,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.4,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.45,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.5,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.55,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.6,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.65,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.7,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.75,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.8,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.85,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.9,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.95,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.975,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,09,quantile,0.99,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.01,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.025,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.05,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.1,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.15,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.2,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.25,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.3,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.35,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.4,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.45,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.5,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.55,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.6,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.65,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.7,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.75,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.8,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.85,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.9,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.95,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.975,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,10,quantile,0.99,12
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.01,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.025,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.05,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.1,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.15,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.2,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.25,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.3,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.35,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.4,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.45,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.5,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.55,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.6,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.65,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.7,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.75,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.8,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.85,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.9,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.95,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.975,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,11,quantile,0.99,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.01,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.025,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.05,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.1,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.15,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.2,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.25,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.3,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.35,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.4,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.45,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.5,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.55,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.6,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.65,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.7,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.75,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.8,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.85,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.9,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.95,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.975,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,12,quantile,0.99,338
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.01,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.025,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.05,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.1,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.15,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.2,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.25,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.3,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.35,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.4,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.45,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.5,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.55,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.6,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.65,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.7,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.75,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.8,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.85,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.9,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.95,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.975,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,13,quantile,0.99,98
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.01,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.025,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.05,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.1,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.15,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.2,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.25,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.3,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.35,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.4,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.45,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.5,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.55,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.6,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.65,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.7,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.75,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.8,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.85,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.9,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.95,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.975,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,15,quantile,0.99,9
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.01,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.025,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.05,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.1,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.15,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.2,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.25,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.3,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.35,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.4,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.45,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.5,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.55,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.6,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.65,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.7,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.75,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.8,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.85,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.9,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.95,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.975,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,16,quantile,0.99,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.01,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.025,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.05,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.1,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.15,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.2,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.25,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.3,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.35,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.4,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.45,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.5,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.55,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.6,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.65,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.7,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.75,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.8,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.85,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.9,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.95,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.975,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,17,quantile,0.99,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.01,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.025,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.05,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.1,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.15,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.2,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.25,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.3,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.35,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.4,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.45,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.5,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.55,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.6,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.65,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.7,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.75,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.8,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.85,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.9,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.95,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.975,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,18,quantile,0.99,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.01,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.025,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.05,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.1,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.15,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.2,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.25,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.3,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.35,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.4,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.45,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.5,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.55,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.6,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.65,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.7,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.75,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.8,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.85,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.9,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.95,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.975,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,19,quantile,0.99,1
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.01,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.025,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.05,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.1,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.15,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.2,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.25,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.3,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.35,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.4,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.45,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.5,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.55,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.6,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.65,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.7,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.75,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.8,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.85,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.9,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.95,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.975,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,20,quantile,0.99,4
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.01,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.025,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.05,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.1,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.15,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.2,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.25,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.3,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.35,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.4,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.45,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.5,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.55,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.6,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.65,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.7,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.75,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.8,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.85,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.9,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.95,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.975,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,21,quantile,0.99,13
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.01,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.025,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.05,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.1,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.15,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.2,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.25,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.3,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.35,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.4,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.45,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.5,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.55,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.6,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.65,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.7,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.75,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.8,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.85,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.9,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.95,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.975,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,22,quantile,0.99,24
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.01,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.025,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.05,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.1,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.15,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.2,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.25,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.3,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.35,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.4,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.45,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.5,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.55,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.6,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.65,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.7,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.75,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.8,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.85,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.9,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.95,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.975,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,23,quantile,0.99,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.01,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.025,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.05,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.1,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.15,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.2,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.25,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.3,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.35,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.4,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.45,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.5,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.55,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.6,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.65,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.7,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.75,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.8,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.85,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.9,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.95,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.975,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,24,quantile,0.99,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.01,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.025,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.05,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.1,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.15,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.2,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.25,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.3,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.35,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.4,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.45,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.5,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.55,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.6,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.65,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.7,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.75,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.8,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.85,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.9,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.95,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.975,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,25,quantile,0.99,17
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.01,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.025,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.05,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.1,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.15,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.2,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.25,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.3,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.35,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.4,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.45,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.5,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.55,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.6,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.65,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.7,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.75,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.8,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.85,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.9,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.95,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.975,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,26,quantile,0.99,8
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.01,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.025,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.05,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.1,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.15,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.2,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.25,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.3,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.35,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.4,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.45,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.5,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.55,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.6,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.65,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.7,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.75,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.8,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.85,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.9,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.95,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.975,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,27,quantile,0.99,18
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.01,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.025,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.05,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.1,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.15,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.2,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.25,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.3,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.35,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.4,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.45,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.5,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.55,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.6,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.65,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.7,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.75,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.8,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.85,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.9,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.95,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.975,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,28,quantile,0.99,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.01,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.025,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.05,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.1,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.15,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.2,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.25,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.3,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.35,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.4,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.45,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.5,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.55,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.6,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.65,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.7,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.75,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.8,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.85,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.9,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.95,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.975,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,29,quantile,0.99,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.01,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.025,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.05,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.1,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.15,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.2,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.25,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.3,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.35,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.4,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.45,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.5,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.55,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.6,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.65,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.7,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.75,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.8,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.85,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.9,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.95,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.975,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,30,quantile,0.99,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.01,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.025,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.05,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.1,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.15,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.2,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.25,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.3,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.35,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.4,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.45,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.5,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.55,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.6,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.65,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.7,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.75,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.8,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.85,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.9,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.95,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.975,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,31,quantile,0.99,6
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.01,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.025,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.05,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.1,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.15,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.2,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.25,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.3,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.35,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.4,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.45,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.5,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.55,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.6,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.65,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.7,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.75,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.8,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.85,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.9,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.95,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.975,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,32,quantile,0.99,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.01,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.025,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.05,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.1,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.15,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.2,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.25,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.3,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.35,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.4,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.45,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.5,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.55,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.6,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.65,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.7,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.75,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.8,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.85,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.9,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.95,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.975,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,33,quantile,0.99,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.01,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.025,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.05,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.1,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.15,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.2,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.25,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.3,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.35,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.4,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.45,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.5,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.55,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.6,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.65,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.7,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.75,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.8,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.85,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.9,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.95,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.975,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,34,quantile,0.99,45
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.01,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.025,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.05,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.1,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.15,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.2,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.25,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.3,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.35,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.4,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.45,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.5,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.55,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.6,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.65,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.7,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.75,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.8,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.85,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.9,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.95,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.975,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,35,quantile,0.99,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.01,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.025,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.05,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.1,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.15,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.2,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.25,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.3,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.35,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.4,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.45,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.5,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.55,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.6,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.65,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.7,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.75,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.8,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.85,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.9,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.95,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.975,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,36,quantile,0.99,88
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.01,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.025,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.05,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.1,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.15,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.2,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.25,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.3,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.35,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.4,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.45,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.5,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.55,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.6,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.65,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.7,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.75,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.8,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.85,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.9,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.95,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.975,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,37,quantile,0.99,26
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.01,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.025,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.05,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.1,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.15,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.2,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.25,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.3,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.35,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.4,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.45,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.5,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.55,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.6,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.65,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.7,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.75,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.8,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.85,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.9,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.95,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.975,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,38,quantile,0.99,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.01,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.025,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.05,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.1,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.15,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.2,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.25,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.3,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.35,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.4,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.45,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.5,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.55,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.6,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.65,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.7,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.75,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.8,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.85,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.9,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.95,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.975,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,39,quantile,0.99,31
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.01,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.025,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.05,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.1,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.15,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.2,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.25,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.3,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.35,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.4,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.45,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.5,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.55,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.6,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.65,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.7,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.75,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.8,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.85,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.9,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.95,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.975,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,40,quantile,0.99,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.01,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.025,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.05,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.1,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.15,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.2,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.25,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.3,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.35,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.4,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.45,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.5,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.55,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.6,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.65,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.7,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.75,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.8,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.85,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.9,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.95,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.975,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,41,quantile,0.99,3
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.01,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.025,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.05,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.1,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.15,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.2,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.25,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.3,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.35,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.4,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.45,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.5,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.55,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.6,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.65,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.7,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.75,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.8,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.85,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.9,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.95,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.975,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,42,quantile,0.99,99
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.01,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.025,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.05,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.1,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.15,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.2,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.25,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.3,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.35,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.4,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.45,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.5,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.55,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.6,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.65,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.7,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.75,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.8,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.85,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.9,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.95,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.975,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,44,quantile,0.99,2
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.01,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.025,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.05,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.1,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.15,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.2,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.25,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.3,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.35,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.4,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.45,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.5,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.55,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.6,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.65,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.7,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.75,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.8,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.85,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.9,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.95,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.975,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,45,quantile,0.99,53
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.01,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.025,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.05,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.1,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.15,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.2,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.25,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.3,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.35,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.4,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.45,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.5,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.55,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.6,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.65,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.7,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.75,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.8,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.85,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.9,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.95,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.975,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,46,quantile,0.99,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.01,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.025,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.05,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.1,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.15,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.2,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.25,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.3,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.35,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.4,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.45,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.5,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.55,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.6,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.65,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.7,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.75,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.8,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.85,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.9,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.95,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.975,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,47,quantile,0.99,15
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.01,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.025,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.05,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.1,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.15,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.2,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.25,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.3,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.35,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.4,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.45,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.5,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.55,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.6,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.65,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.7,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.75,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.8,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.85,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.9,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.95,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.975,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,48,quantile,0.99,153
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.01,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.025,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.05,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.1,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.15,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.2,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.25,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.3,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.35,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.4,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.45,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.5,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.55,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.6,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.65,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.7,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.75,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.8,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.85,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.9,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.95,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.975,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,49,quantile,0.99,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.01,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.025,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.05,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.1,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.15,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.2,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.25,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.3,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.35,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.4,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.45,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.5,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.55,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.6,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.65,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.7,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.75,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.8,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.85,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.9,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.95,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.975,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,50,quantile,0.99,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.01,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.025,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.05,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.1,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.15,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.2,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.25,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.3,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.35,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.4,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.45,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.5,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.55,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.6,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.65,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.7,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.75,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.8,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.85,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.9,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.95,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.975,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,51,quantile,0.99,25
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.01,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.025,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.05,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.1,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.15,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.2,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.25,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.3,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.35,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.4,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.45,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.5,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.55,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.6,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.65,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.7,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.75,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.8,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.85,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.9,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.95,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.975,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,53,quantile,0.99,7
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.01,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.025,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.05,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.1,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.15,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.2,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.25,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.3,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.35,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.4,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.45,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.5,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.55,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.6,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.65,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.7,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.75,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.8,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.85,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.9,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.95,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.975,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,54,quantile,0.99,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.01,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.025,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.05,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.1,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.15,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.2,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.25,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.3,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.35,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.4,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.45,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.5,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.55,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.6,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.65,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.7,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.75,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.8,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.85,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.9,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.95,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.975,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,55,quantile,0.99,5
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.01,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.025,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.05,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.1,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.15,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.2,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.25,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.3,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.35,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.4,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.45,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.5,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.55,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.6,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.65,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.7,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.75,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.8,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.85,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.9,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.95,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.975,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,56,quantile,0.99,0
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.01,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.025,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.05,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.1,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.15,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.2,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.25,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.3,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.35,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.4,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.45,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.5,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.55,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.6,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.65,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.7,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.75,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.8,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.85,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.9,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.95,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.975,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,72,quantile,0.99,135
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.01,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.025,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.05,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.1,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.15,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.2,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.25,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.3,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.35,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.4,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.45,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.5,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.55,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.6,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.65,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.7,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.75,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.8,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.85,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.9,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.95,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.975,1432
+2025-11-22,-1,wk inc rsv hosp,2025-11-15,US,quantile,0.99,1432
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.025,4.125000000000006
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.05,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.1,20
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.15,24.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.2,26
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.25,27
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.3,28
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.35,29
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.4,30
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.45,30
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.5,31
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.55,32
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.6,32
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.65,33
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.7,34
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.75,35
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.8,36
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.85,37.24999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.9,42
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.95,50
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.975,57.87499999999995
+2025-11-22,0,wk inc rsv hosp,2025-11-22,01,quantile,0.99,66.69999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.3,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.35,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.4,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.45,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.5,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.55,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.6,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.65,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.7,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.75,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.8,4.000168001680028
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.85,9
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.9,10.500000000000002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.95,13.749999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.975,17
+2025-11-22,0,wk inc rsv hosp,2025-11-22,02,quantile,0.99,17.949999999999992
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.35,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.4,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.45,3.250000000000007
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.5,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.55,4.7500000000000036
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.6,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.65,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.7,8.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.75,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.8,14.999831998319987
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.85,20.249999999999964
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.9,45.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.95,77.99999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.975,93.62499999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,04,quantile,0.99,102.74999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.2,1.9998319983199853
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.25,3.2499999999999982
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.3,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.35,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.4,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.45,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.5,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.55,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.6,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.65,9
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.7,9
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.75,10.750000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.8,12.000168001680027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.85,14.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.9,19.500000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.95,24.249999999999975
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.975,27.124999999999968
+2025-11-22,0,wk inc rsv hosp,2025-11-22,05,quantile,0.99,32.79999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.1,6.500000000000007
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.15,21
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.2,34.00016800168003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.25,48.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.3,56
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.35,58.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.4,61.99974799747998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.45,64
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.5,65
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.55,66
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.6,68.00025200252003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.65,71.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.7,74
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.75,81.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.8,95.99983199832002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.85,108.99999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.9,123.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.95,161.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.975,185.87499999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,06,quantile,0.99,194.69999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.25,2.2499999999999982
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.3,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.35,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.4,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.45,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.5,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.55,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.6,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.65,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.7,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.75,9.750000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.8,14.000000000000014
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.85,22.749999999999975
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.9,35.00000000000001
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.95,39.49999999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.975,51.74999999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,08,quantile,0.99,63.44999999999992
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.2,1.6800168001854856e-4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.25,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.3,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.35,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.4,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.45,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.5,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.55,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.6,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.65,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.7,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.75,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.8,8.000000000000014
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.85,11
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.9,13.500000000000002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.95,41.49999999999992
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.975,50.124999999999964
+2025-11-22,0,wk inc rsv hosp,2025-11-22,09,quantile,0.99,52
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.1,4.500000000000003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.15,8.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.2,9.999831998319985
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.25,11
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.3,11
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.35,11.749999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.4,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.45,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.5,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.55,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.6,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.65,12.250000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.7,13
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.75,13
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.8,14.000168001680027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.85,15.249999999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.9,19.500000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.95,27.74999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.975,38.749999999999886
+2025-11-22,0,wk inc rsv hosp,2025-11-22,10,quantile,0.99,62.099999999999866
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.2,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.25,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.3,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.35,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.4,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.45,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.5,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.55,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.6,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.65,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.7,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.75,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.8,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.85,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.9,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.95,6.749999999999992
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.975,12.749999999999979
+2025-11-22,0,wk inc rsv hosp,2025-11-22,11,quantile,0.99,18.74999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.01,209.55
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.025,240.875
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.05,259.49999999999994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.1,297.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.15,306.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.2,314
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.25,320
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.3,325
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.35,326.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.4,329.99974799748
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.45,333.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.5,338
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.55,342.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.6,346.00025200252003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.65,349.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.7,351
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.75,356
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.8,362
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.85,369.24999999999994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.9,378.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.95,416.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.975,435.125
+2025-11-22,0,wk inc rsv hosp,2025-11-22,12,quantile,0.99,466.4499999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.025,13.750000000000005
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.05,45.25000000000001
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.1,70.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.15,85.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.2,89.00016800168001
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.25,91
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.3,93
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.35,94.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.4,96
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.45,97
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.5,98
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.55,99
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.6,100
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.65,101.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.7,103
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.75,105
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.8,106.99983199831999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.85,110.49999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.9,125.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.95,150.74999999999994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.975,182.24999999999983
+2025-11-22,0,wk inc rsv hosp,2025-11-22,13,quantile,0.99,220.4499999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.05,0.2500000000000002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.1,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.15,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.2,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.25,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.3,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.35,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.4,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.45,9
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.5,9
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.55,9
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.6,10
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.65,11
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.7,11
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.75,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.8,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.85,13
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.9,15
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.95,17.74999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.975,20
+2025-11-22,0,wk inc rsv hosp,2025-11-22,15,quantile,0.99,30.449999999999918
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.35,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.4,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.45,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.5,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.55,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.6,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.65,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.7,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.75,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.8,3.0001680016800276
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.85,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.9,10
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.95,15.499999999999984
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.975,21.499999999999957
+2025-11-22,0,wk inc rsv hosp,2025-11-22,16,quantile,0.99,25.899999999999984
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.25,7.4999999999999964
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.3,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.35,13
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.4,14.00025200252003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.45,16
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.5,17
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.55,18
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.6,19.999747997479975
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.65,21
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.7,22
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.75,26.500000000000007
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.8,34.99932799327995
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.85,45.74999999999994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.9,69.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.95,104.24999999999994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.975,134.99999999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,17,quantile,0.99,209.34999999999943
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.15,1.7500000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.2,6.9996639966399705
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.25,10
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.3,11.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.35,13
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.4,14
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.45,15
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.5,15
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.55,15
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.6,16
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.65,17
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.7,18.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.75,20
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.8,23.000336003360054
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.85,28.249999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.9,46.50000000000001
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.95,67.49999999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.975,80.87499999999994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,18,quantile,0.99,121.9999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.35,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.4,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.45,0.2500000000000073
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.5,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.55,1.7500000000000036
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.6,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.65,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.7,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.75,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.8,6.000000000000014
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.85,12.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.9,18
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.95,29.74999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.975,85.37499999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,19,quantile,0.99,91.69999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.25,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.3,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.35,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.4,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.45,3.250000000000007
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.5,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.55,4.7500000000000036
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.6,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.65,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.7,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.75,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.8,9.000000000000014
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.85,13
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.9,16.500000000000007
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.95,29.249999999999975
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.975,37.374999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,20,quantile,0.99,41.79999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.15,0.7500000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.2,5.999831998319985
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.25,9.249999999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.3,10.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.35,11
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.4,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.45,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.5,13
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.55,14
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.6,14
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.65,15
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.7,15.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.75,16.750000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.8,20.000168001680027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.85,25.249999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.9,34.00000000000001
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.95,47.99999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.975,66.49999999999987
+2025-11-22,0,wk inc rsv hosp,2025-11-22,21,quantile,0.99,134.79999999999953
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.1,7.500000000000009
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.15,15.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.2,18.000168001680017
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.25,19.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.3,22
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.35,22
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.4,22.00025200252003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.45,24
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.5,24
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.55,24
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.6,25.999747997479975
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.65,26
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.7,26
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.75,28.750000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.8,29.999831998319987
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.85,32.24999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.9,40.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.95,59.99999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.975,81.49999999999977
+2025-11-22,0,wk inc rsv hosp,2025-11-22,22,quantile,0.99,103.49999999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.35,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.4,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.45,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.5,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.55,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.6,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.65,0.25000000000000255
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.7,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.75,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.8,1.0001680016800276
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.85,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.9,4.500000000000002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.95,6.749999999999992
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.975,7.749999999999978
+2025-11-22,0,wk inc rsv hosp,2025-11-22,23,quantile,0.99,9
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.1,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.15,15
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.2,19
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.25,21
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.3,22
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.35,24
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.4,24
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.45,25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.5,26
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.55,27
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.6,28
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.65,28
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.7,30
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.75,31
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.8,33
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.85,37
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.9,40
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.95,58.24999999999994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.975,80
+2025-11-22,0,wk inc rsv hosp,2025-11-22,24,quantile,0.99,103.74999999999982
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.2,7.999159991599926
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.25,9.249999999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.3,11.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.35,13
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.4,14
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.45,16
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.5,17
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.55,18
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.6,20
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.65,21
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.7,22.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.75,24.750000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.8,26.00084000840014
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.85,36
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.9,44
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.95,75.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.975,103.9999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,25,quantile,0.99,166.94999999999953
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.3,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.35,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.4,7.000252002520029
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.45,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.5,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.55,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.6,8.999747997479975
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.65,10
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.7,11
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.75,21.000000000000014
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.8,27.000000000000014
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.85,46.24999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.9,55.000000000000014
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.95,91.99999999999994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.975,104.49999999999987
+2025-11-22,0,wk inc rsv hosp,2025-11-22,26,quantile,0.99,149.0499999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.15,1.5000000000000009
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.2,8.999831998319989
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.25,15
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.3,16
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.35,16.749999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.4,17
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.45,18
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.5,18
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.55,18
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.6,19
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.65,19.250000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.7,20
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.75,21
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.8,27.00016800168004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.85,34.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.9,42
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.95,45.74999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.975,52
+2025-11-22,0,wk inc rsv hosp,2025-11-22,27,quantile,0.99,67.19999999999989
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.2,1.0001680016800185
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.25,2.2499999999999982
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.3,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.35,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.4,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.45,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.5,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.55,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.6,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.65,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.7,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.75,7.7500000000000036
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.8,8.999831998319987
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.85,11.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.9,16
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.95,23.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.975,26
+2025-11-22,0,wk inc rsv hosp,2025-11-22,28,quantile,0.99,35.49999999999992
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.3,2.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.35,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.4,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.45,4.250000000000007
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.5,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.55,5.7500000000000036
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.6,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.65,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.7,7.499999999999985
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.75,10
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.8,15.000168001680027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.85,21
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.9,30.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.95,41.74999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.975,62.999999999999915
+2025-11-22,0,wk inc rsv hosp,2025-11-22,29,quantile,0.99,82.24999999999989
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.35,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.4,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.45,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.5,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.55,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.6,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.65,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.7,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.75,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.8,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.85,3.2499999999999925
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.9,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.95,12.749999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.975,17.874999999999943
+2025-11-22,0,wk inc rsv hosp,2025-11-22,30,quantile,0.99,32.399999999999906
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.15,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.2,3.9998319983199853
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.25,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.3,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.35,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.4,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.45,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.5,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.55,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.6,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.65,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.7,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.75,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.8,8.000168001680027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.85,11
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.9,15.000000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.95,21.999999999999968
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.975,29
+2025-11-22,0,wk inc rsv hosp,2025-11-22,31,quantile,0.99,35.64999999999995
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.25,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.3,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.35,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.4,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.45,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.5,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.55,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.6,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.65,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.7,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.75,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.8,4.000168001680028
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.85,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.9,12
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.95,22.74999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.975,26.37499999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,32,quantile,0.99,35.54999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.2,1.0001680016800185
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.25,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.3,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.35,2.7499999999999925
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.4,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.45,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.5,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.55,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.6,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.65,3.2500000000000027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.7,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.75,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.8,4.999831998319987
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.85,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.9,8.500000000000002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.95,14
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.975,17
+2025-11-22,0,wk inc rsv hosp,2025-11-22,33,quantile,0.99,17
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.1,3.0000000000000178
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.15,27.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.2,34.99966399663997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.25,38
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.3,38.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.35,40.74999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.4,42
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.45,44
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.5,45
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.55,46
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.6,48
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.65,49.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.7,51.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.75,52
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.8,55.000336003360054
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.85,62.74999999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.9,87.00000000000001
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.95,117.99999999999984
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.975,155.74999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,34,quantile,0.99,160.79999999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.25,0.24999999999999822
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.3,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.35,1.7499999999999925
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.4,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.45,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.5,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.55,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.6,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.65,2.2500000000000027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.7,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.75,3.7500000000000036
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.8,4.999831998319987
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.85,6.249999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.9,13.000000000000012
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.95,28.74999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.975,31.37499999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,35,quantile,0.99,48.14999999999987
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.15,41.50000000000001
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.2,64.00033600336005
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.25,73
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.3,77.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.35,81
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.4,83.00025200252003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.45,86
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.5,88
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.55,90
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.6,92.99974799747997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.65,95
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.7,98.49999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.75,103
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.8,111.99966399664002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.85,134.49999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.9,176.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.95,234.49999999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.975,254.1249999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,36,quantile,0.99,276.1999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.15,0.7500000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.2,10.00033600336004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.25,16.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.3,20.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.35,23.749999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.4,24.00025200252003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.45,25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.5,26
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.55,27
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.6,27.999747997479975
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.65,28.250000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.7,31.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.75,35.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.8,41.999663996639995
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.85,51.24999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.9,65.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.95,104
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.975,150.4999999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,37,quantile,0.99,215.2499999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.35,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.4,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.45,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.5,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.55,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.6,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.65,0.25000000000000255
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.7,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.75,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.8,1.0001680016800276
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.85,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.9,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.95,6.749999999999992
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.975,12.374999999999988
+2025-11-22,0,wk inc rsv hosp,2025-11-22,38,quantile,0.99,18.699999999999953
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.15,12.500000000000002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.2,20.99949599495996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.25,23
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.3,26.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.35,28
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.4,29
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.45,29.250000000000007
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.5,31
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.55,32.75000000000001
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.6,33
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.65,34
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.7,35.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.75,39
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.8,41.0005040050401
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.85,49.49999999999995
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.9,73.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.95,111.24999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.975,158.24999999999923
+2025-11-22,0,wk inc rsv hosp,2025-11-22,39,quantile,0.99,219.09999999999988
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.35,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.4,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.45,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.5,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.55,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.6,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.65,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.7,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.75,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.8,5.999831998319987
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.85,10.249999999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.9,16
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.95,25.74999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.975,32.62499999999992
+2025-11-22,0,wk inc rsv hosp,2025-11-22,40,quantile,0.99,39.84999999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.25,0.24999999999999822
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.3,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.35,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.4,2.000252002520029
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.45,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.5,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.55,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.6,3.999747997479975
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.65,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.7,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.75,5.7500000000000036
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.8,7.000168001680027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.85,10.99999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.9,20.000000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.95,41.99999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.975,51
+2025-11-22,0,wk inc rsv hosp,2025-11-22,41,quantile,0.99,58.599999999999945
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.1,17
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.15,32.75000000000001
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.2,61.99899198991994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.25,80
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.3,83
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.35,90
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.4,92
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.45,95.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.5,99
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.55,102.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.6,106
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.65,108
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.7,115
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.75,118
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.8,136.0010080100803
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.85,165.24999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.9,181
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.95,217.74999999999994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.975,303.74999999999926
+2025-11-22,0,wk inc rsv hosp,2025-11-22,42,quantile,0.99,414.34999999999945
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.3,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.35,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.4,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.45,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.5,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.55,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.6,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.65,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.7,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.75,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.8,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.85,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.9,6.500000000000002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.95,14
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.975,17.124999999999968
+2025-11-22,0,wk inc rsv hosp,2025-11-22,44,quantile,0.99,30.39999999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.05,13.249999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.1,27.500000000000007
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.15,41
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.2,44.00033600336004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.25,47.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.3,49.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.35,50.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.4,51.99974799747998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.45,52
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.5,53
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.55,54
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.6,54.00025200252003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.65,55.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.7,56.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.75,58.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.8,61.999663996639974
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.85,65
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.9,78.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.95,92.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.975,108.37499999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,45,quantile,0.99,153.64999999999964
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.35,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.4,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.45,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.5,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.55,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.6,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.65,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.7,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.75,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.8,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.85,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.9,4.500000000000002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.95,9.499999999999984
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.975,14
+2025-11-22,0,wk inc rsv hosp,2025-11-22,46,quantile,0.99,15.899999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.15,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.2,9.999831998319985
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.25,11.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.3,12.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.35,14
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.4,14
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.45,15
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.5,15
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.55,15
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.6,16
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.65,16
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.7,17.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.75,18.750000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.8,20.000168001680027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.85,27
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.9,32
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.95,52.24999999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.975,74.62499999999983
+2025-11-22,0,wk inc rsv hosp,2025-11-22,47,quantile,0.99,121.04999999999971
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.025,4.875000000000003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.05,20.750000000000036
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.1,81.49999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.15,111
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.2,124.99983199831999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.25,138
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.3,144
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.35,144
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.4,147.00025200252003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.45,150
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.5,153
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.55,156
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.6,158.99974799747997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.65,162
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.7,162
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.75,168
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.8,181.00016800168004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.85,194.99999999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.9,224.49999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.95,285.2499999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.975,301.125
+2025-11-22,0,wk inc rsv hosp,2025-11-22,48,quantile,0.99,315.3499999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.35,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.4,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.45,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.5,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.55,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.6,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.65,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.7,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.75,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.8,4.000336003360055
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.85,6.249999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.9,14.000000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.95,38.499999999999886
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.975,51
+2025-11-22,0,wk inc rsv hosp,2025-11-22,49,quantile,0.99,52.899999999999984
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.35,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.4,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.45,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.5,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.55,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.6,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.65,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.7,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.75,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.8,1.0001680016800276
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.85,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.9,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.95,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.975,8.374999999999988
+2025-11-22,0,wk inc rsv hosp,2025-11-22,50,quantile,0.99,10.899999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.1,4.500000000000009
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.15,13.500000000000002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.2,17.000168001680017
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.25,20
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.3,21.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.35,22
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.4,23
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.45,24
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.5,25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.55,26
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.6,27
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.65,28
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.7,28.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.75,30
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.8,32.99983199831999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.85,36.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.9,45.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.95,65.74999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.975,96.87499999999942
+2025-11-22,0,wk inc rsv hosp,2025-11-22,51,quantile,0.99,150.89999999999984
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.2,1.0001680016800185
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.25,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.3,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.35,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.4,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.45,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.5,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.55,7
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.6,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.65,9
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.7,9
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.75,10
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.8,12.999831998319987
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.85,18.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.9,25.000000000000004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.95,33.74999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.975,37.87499999999995
+2025-11-22,0,wk inc rsv hosp,2025-11-22,53,quantile,0.99,59.99999999999985
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.35,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.4,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.45,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.5,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.55,0.7500000000000036
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.6,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.65,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.7,3
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.75,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.8,5.000168001680027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.85,9.249999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.9,13.500000000000002
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.95,23.499999999999986
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.975,33.49999999999978
+2025-11-22,0,wk inc rsv hosp,2025-11-22,54,quantile,0.99,46.949999999999996
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.25,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.3,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.35,2
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.4,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.45,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.5,5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.55,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.6,6
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.65,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.7,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.75,9
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.8,11.000168001680027
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.85,15.249999999999991
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.9,26.00000000000001
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.95,38
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.975,44
+2025-11-22,0,wk inc rsv hosp,2025-11-22,55,quantile,0.99,45.899999999999984
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.1,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.15,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.2,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.25,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.3,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.35,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.4,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.45,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.5,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.55,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.6,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.65,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.7,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.75,1
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.8,2.0001680016800276
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.85,4
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.9,8
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.95,10.749999999999993
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.975,13.874999999999945
+2025-11-22,0,wk inc rsv hosp,2025-11-22,56,quantile,0.99,17.949999999999992
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.025,51.125000000000014
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.05,72
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.1,98
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.15,115.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.2,123.99983199831999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.25,126.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.3,130
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.35,131.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.4,133.99974799747997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.45,134
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.5,135
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.55,136
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.6,136.00025200252003
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.65,138.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.7,140
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.75,143.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.8,146.00016800168004
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.85,154.25
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.9,172
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.95,197.99999999999997
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.975,218.87499999999977
+2025-11-22,0,wk inc rsv hosp,2025-11-22,72,quantile,0.99,297.54999999999944
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.01,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.025,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.05,0
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.1,420.99999999999994
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.15,734.75
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.2,1033.0036960369605
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.25,1213.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.3,1326
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.35,1371
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.4,1398.00050400504
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.45,1418
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.5,1432
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.55,1446
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.6,1465.99949599496
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.65,1493
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.7,1538
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.75,1650.5
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.8,1830.9963039630397
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.85,2129.2499999999995
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.9,2443
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.95,2892.999999999999
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.975,3324.499999999998
+2025-11-22,0,wk inc rsv hosp,2025-11-22,US,quantile,0.99,4666.499999999991
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.05,4.033063330633314
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.1,12
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.15,17.12892778927789
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.2,21
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.25,24
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.3,26
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.35,27
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.4,28.854864548645494
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.45,30
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.5,31
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.55,32
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.6,33.28195481954818
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.65,35
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.7,36.12910629106288
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.75,38
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.8,41
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.85,45
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.9,50
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.95,58.613279632796186
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.975,67.25851258512584
+2025-11-22,1,wk inc rsv hosp,2025-11-29,01,quantile,0.99,78.13726997269963
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.35,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.4,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.45,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.5,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.55,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.6,3.365391653916535
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.65,4.038481384813847
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.7,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.75,8
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.8,10
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.85,11.330996309963096
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.9,13.992727927279272
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.95,17.228753787537837
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.975,19.34295367953679
+2025-11-22,1,wk inc rsv hosp,2025-11-29,02,quantile,0.99,24
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.4,0.5741457414574214
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.45,2.5741457414574214
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.5,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.55,6.484279842798438
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.6,9.26483664836649
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.65,11.675305253052542
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.7,14.990372903729037
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.75,22.658559085590866
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.8,35.559985599856
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.85,50.39516845168443
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.9,75.38332583325848
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.95,94.57864128641266
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.975,109.20535355353533
+2025-11-22,1,wk inc rsv hosp,2025-11-29,04,quantile,0.99,131.41163921639185
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.25,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.3,2.470785707857078
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.35,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.4,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.45,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.5,7
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.55,8.193003930039309
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.6,9.305313053130522
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.65,11
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.7,12.800006000059991
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.75,14.667319173191732
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.8,17.23414634146342
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.85,20.26493864938648
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.9,24
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.95,29.201552515525137
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.975,33.765351153511496
+2025-11-22,1,wk inc rsv hosp,2025-11-29,05,quantile,0.99,39.01546755467553
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.15,3.7733777337773224
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.2,14.077682776827796
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.25,25.962867128671284
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.3,38.231980319803185
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.35,48.950873008730085
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.4,56
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.45,61
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.5,65
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.55,69.9568970689707
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.6,74.99492994929949
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.65,83.07274772747729
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.7,94.93708937089355
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.75,106.69625446254464
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.8,119.13380133801344
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.85,135.38902289022894
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.9,161.59901599015993
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.95,190.35901509015082
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.975,216.2675854258542
+2025-11-22,1,wk inc rsv hosp,2025-11-29,06,quantile,0.99,246.34703447034445
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.3,0.5701257012570125
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.35,2.5701257012570125
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.4,3.5701257012570125
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.45,5.148978489784898
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.5,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.55,7.5701257012570125
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.6,8.858134581345812
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.65,11.58349083490836
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.7,15.80970209702092
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.75,23.107521075210734
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.8,30.570125701257012
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.85,35.57012570125701
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.9,42.57012570125701
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.95,54.7299087990879
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.975,67.17108046080443
+2025-11-22,1,wk inc rsv hosp,2025-11-29,08,quantile,0.99,80.1331572315723
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.3,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.35,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.4,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.45,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.5,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.55,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.6,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.65,7
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.7,8.95632256322563
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.75,10.965394653946543
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.8,13
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.85,17.27027270272698
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.9,37.930336303363106
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.95,49.29183091830915
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.975,52.591578165781655
+2025-11-22,1,wk inc rsv hosp,2025-11-29,09,quantile,0.99,58.152335523355234
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.1,0.39558095580955566
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.15,3.239544895448953
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.2,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.25,8.130126301263013
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.3,9.566366663666638
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.35,10.573269732697323
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.4,11
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.45,12
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.5,12
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.55,12
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.6,13
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.65,13.661820118201192
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.7,14.722686226862272
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.75,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.8,18.426322263222637
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.85,21
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.9,26.568838688386904
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.95,38.768358683586754
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.975,57.63496534965315
+2025-11-22,1,wk inc rsv hosp,2025-11-29,10,quantile,0.99,81.72564215642177
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.3,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.35,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.4,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.45,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.5,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.55,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.6,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.65,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.7,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.75,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.8,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.85,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.9,6.866066660666606
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.95,12.498049980499772
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.975,17.234621096210937
+2025-11-22,1,wk inc rsv hosp,2025-11-29,11,quantile,0.99,19.618856688566883
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.01,169.7743647436474
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.025,205.43274007740078
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.05,231.35564455644558
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.1,259.89497194971955
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.15,281.2677511775118
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.2,296.0059700597006
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.25,306.72674226742265
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.3,314.19307593075933
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.35,320.14838148381483
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.4,326.8709267092671
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.45,332.7712117121172
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.5,338
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.55,343.16471214712146
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.6,349.11517115171154
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.65,355.7767227672277
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.7,361.88610986109865
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.75,369.39194641946415
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.8,380.04484444844456
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.85,394.58183331833305
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.9,415.8858068580687
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.95,444.45186901869016
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.975,470.64798622986206
+2025-11-22,1,wk inc rsv hosp,2025-11-29,12,quantile,0.99,506.28534245342416
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.05,14.824258242582431
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.1,48.722869228692296
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.15,67.61980469804696
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.2,76.98058980589806
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.25,84
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.3,88.11324213242133
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.35,91
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.4,93.99528395283951
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.45,96
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.5,98
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.55,100
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.6,102.06981069810698
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.65,105
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.7,107.76500765007651
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.75,112
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.8,119
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.85,128.02050820508205
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.9,147.79504095040954
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.95,182.7126721267208
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.975,213.87496174961757
+2025-11-22,1,wk inc rsv hosp,2025-11-29,13,quantile,0.99,253.49789607896028
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.1,0.5866648666486675
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.15,2.1602931029310293
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.2,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.25,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.3,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.35,7
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.4,7.436366363663638
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.45,8
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.5,9
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.55,10
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.6,10.708037080370797
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.65,11.017611676116768
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.7,12
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.75,13
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.8,14.307167071670737
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.85,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.9,18
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.95,21.930781807818075
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.975,27.784285092850745
+2025-11-22,1,wk inc rsv hosp,2025-11-29,15,quantile,0.99,36.88320673206723
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.4,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.45,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.5,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.55,1.9981699816998173
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.6,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.65,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.7,5.044241442414421
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.75,7
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.8,10
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.85,12.33454834548344
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.9,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.95,22.84402694026936
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.975,27.09973224732258
+2025-11-22,1,wk inc rsv hosp,2025-11-29,16,quantile,0.99,32.81832238322386
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.3,3.405376053760534
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.35,8
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.4,11.607434074340746
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.45,14.73766237662377
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.5,17
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.55,20
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.6,23.46746467464674
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.65,28.95999309993104
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.7,36.56316263162631
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.75,47.18889688896894
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.8,61.250340503405184
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.85,80.82865328653286
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.9,103.84289442894428
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.95,139.52748927489293
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.975,195.5256697566976
+2025-11-22,1,wk inc rsv hosp,2025-11-29,17,quantile,0.99,222.0784402844029
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.2,0.3804458044580529
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.25,3.279182791827921
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.3,7
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.35,10
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.4,12.179983799838002
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.45,14
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.5,15
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.55,16.86432964329643
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.6,18.99954999549996
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.65,21
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.7,25.21040710407103
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.75,29.91135661356614
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.8,40.349617496175
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.85,51
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.9,64.45287552875533
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.95,83.74948549485487
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.975,112.61833693336924
+2025-11-22,1,wk inc rsv hosp,2025-11-29,18,quantile,0.99,126.95758767587654
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.4,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.45,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.5,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.55,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.6,2.5904959049590484
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.65,4.1696411964119635
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.7,7.193651936519359
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.75,12
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.8,16.317157171571736
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.85,21.492690426904275
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.9,30.591287912879157
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.95,83.2348093480935
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.975,91.37863378633787
+2025-11-22,1,wk inc rsv hosp,2025-11-29,19,quantile,0.99,103.26861038610386
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.3,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.35,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.4,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.45,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.5,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.55,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.6,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.65,7.464886148861488
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.7,10
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.75,12.395486454864528
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.8,15.599909999099996
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.85,21.034092340923394
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.9,28.418135181351836
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.95,37.54376593765935
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.975,43.36779992799926
+2025-11-22,1,wk inc rsv hosp,2025-11-29,20,quantile,0.99,50.354753547535495
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.2,0.9082410824108299
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.25,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.3,6.365106651066511
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.35,9
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.4,10.95783157831579
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.45,12
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.5,13
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.55,14.582853328533286
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.6,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.65,18.20151201512016
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.7,21.179812798127987
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.75,25.22254222542226
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.8,31.499672996729977
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.85,37.62708577085769
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.9,47
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.95,68.36946869468684
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.975,116.71546065460612
+2025-11-22,1,wk inc rsv hosp,2025-11-29,21,quantile,0.99,141.33342633426335
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.15,4.516042660426601
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.2,10.93180331803318
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.25,15.125168751687514
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.3,18
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.35,20
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.4,21.50258902589026
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.45,23
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.5,24
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.55,25.39198391983919
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.6,27
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.65,28.192891428914287
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.7,30.438964389643886
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.75,33.438281882818856
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.8,38
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.85,46
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.9,58.067062670626726
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.95,80.59656346563462
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.975,99.58847388473882
+2025-11-22,1,wk inc rsv hosp,2025-11-29,22,quantile,0.99,106.84039840398404
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.4,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.45,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.5,1.3500135001365265e-4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.55,0.5028350283502832
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.6,0.5028350283502832
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.65,0.7187291872918748
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.7,1.5028350283502832
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.75,2.502835028350283
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.8,3.502835028350283
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.85,5.502835028350283
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.9,6.502835028350283
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.95,8.502835028350283
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.975,9.502835028350283
+2025-11-22,1,wk inc rsv hosp,2025-11-29,23,quantile,0.99,11.525806258062573
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.1,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.15,7.911625116251156
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.2,12.705421054210543
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.25,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.3,18.649080490804906
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.35,21
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.4,22.818078180781818
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.45,24.390423904239054
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.5,26
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.55,27.769860198601997
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.6,29.292358923589227
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.65,31.175492754927554
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.7,33.58872288722886
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.75,36.08864338643387
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.8,39.833558335583376
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.85,45.2470809708097
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.9,57.09139591395917
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.95,79.45469204692047
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.975,98.64852473524715
+2025-11-22,1,wk inc rsv hosp,2025-11-29,24,quantile,0.99,121.01858308583076
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.25,3.457924579245791
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.3,6.457924579245791
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.35,9.26537515375153
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.4,12.31436714367144
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.45,14.457924579245791
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.5,17
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.55,19.45792457924579
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.6,22.05667656676566
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.65,25.284470344703443
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.7,28.69158491584909
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.75,34.092925929259295
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.8,40.586187861878685
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.85,50.49339543395433
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.9,72.31719017190173
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.95,104.61758617586165
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.975,152.3108511085105
+2025-11-22,1,wk inc rsv hosp,2025-11-29,25,quantile,0.99,224.78392493924918
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.35,1.0722167221672092
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.4,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.45,7
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.5,8
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.55,10
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.6,16.668736687366867
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.65,23.462532625326254
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.7,29.285743857438547
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.75,43
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.8,50.73473734737348
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.85,68.4732637326373
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.9,89.08543485434853
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.95,114.24712897128971
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.975,151.96185536855359
+2025-11-22,1,wk inc rsv hosp,2025-11-29,26,quantile,0.99,203.77850328503257
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.2,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.25,4.638968889688897
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.3,9.96957369573698
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.35,14.051108511085108
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.4,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.45,17
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.5,18
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.55,19
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.6,20.549227492274923
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.65,23
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.7,27.486964869648688
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.75,32.579980799808
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.8,37.931251312513176
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.85,42.95876458764586
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.9,46.553508535085356
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.95,57.76389163891638
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.975,69.88873938739387
+2025-11-22,1,wk inc rsv hosp,2025-11-29,27,quantile,0.99,82.66282302823018
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.25,0.7186871868718683
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.3,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.35,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.4,3.5194311943119447
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.45,4.444365943659436
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.5,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.55,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.6,7
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.65,8
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.7,9.909759097590978
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.75,11.944206942069421
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.8,15
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.85,18.77269522695227
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.9,22.955278552785522
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.95,28
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.975,34.92484174841747
+2025-11-22,1,wk inc rsv hosp,2025-11-29,28,quantile,0.99,39.7039180391804
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.35,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.4,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.45,3.626233762337627
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.5,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.55,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.6,8.420940209402087
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.65,12
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.7,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.75,21.614526145261443
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.8,27.46498064980652
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.85,33
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.9,41.999108991089884
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.95,63.28656136561352
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.975,79.77707452074533
+2025-11-22,1,wk inc rsv hosp,2025-11-29,29,quantile,0.99,90.79251282512827
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.4,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.45,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.5,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.55,0.6111061110611047
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.6,1.6111061110611047
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.65,1.6111061110611047
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.7,2.6111061110611047
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.75,4.543522935229344
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.8,7.611106111061105
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.85,9.611106111061105
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.9,12.593210932109315
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.95,19.042618426184223
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.975,29.322951729517087
+2025-11-22,1,wk inc rsv hosp,2025-11-29,30,quantile,0.99,32.611106111061105
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.2,0.8894428944289459
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.25,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.3,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.35,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.4,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.45,5.496603966039659
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.5,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.55,7
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.6,7.070860708607075
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.65,8
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.7,9.142708427084264
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.75,11
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.8,13.044658446584476
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.85,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.9,21.554588545885448
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.95,29.821666216662138
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.975,34.82025320253196
+2025-11-22,1,wk inc rsv hosp,2025-11-29,31,quantile,0.99,39.609819998199974
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.3,0.31545615456154413
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.35,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.4,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.45,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.5,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.55,2.5552995529955393
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.6,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.65,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.7,5.365151651516521
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.75,7.898066480664795
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.8,11.033762337623395
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.85,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.9,21.825755257552597
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.95,27.12299072990729
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.975,35.92366798667977
+2025-11-22,1,wk inc rsv hosp,2025-11-29,32,quantile,0.99,46.598379383793706
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.25,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.3,1.102016020160202
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.35,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.4,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.45,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.5,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.55,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.6,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.65,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.7,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.75,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.8,7.394653946539491
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.85,11.331924819248187
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.9,14
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.95,17
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.975,18.71033360333602
+2025-11-22,1,wk inc rsv hosp,2025-11-29,33,quantile,0.99,22.19119221192212
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.15,4.606280562805624
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.2,16.491212912129132
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.25,27.351116011160116
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.3,33
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.35,36.88678486784866
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.4,40
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.45,42.693338433384334
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.5,45
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.55,48
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.6,50.70785107851077
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.65,54
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.7,58
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.75,64.03326283262834
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.8,76.43563435634357
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.85,91.45318603186026
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.9,111.05732457324585
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.95,149.80825308253085
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.975,162.64070590705902
+2025-11-22,1,wk inc rsv hosp,2025-11-29,34,quantile,0.99,175.83184081840804
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.35,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.4,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.45,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.5,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.55,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.6,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.65,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.7,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.75,7
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.8,9.89613896138961
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.85,17.263206132061313
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.9,27.9169651696517
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.95,32.64946899468993
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.975,46.84676446764448
+2025-11-22,1,wk inc rsv hosp,2025-11-29,35,quantile,0.99,65.15611646116446
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.15,2.5143236432364358
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.2,21.754057540575417
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.25,46.685806858068595
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.3,62.03025830258302
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.35,71.56741817418174
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.4,77.96014160141604
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.45,83.65798307983081
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.5,88
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.55,93.08534335343356
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.6,98.75405754057542
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.65,105.46669216692169
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.7,116.15509555095538
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.75,132.68565685656858
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.8,160.35336753367537
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.85,185.54622896228963
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.9,225.33070530705317
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.95,262.32623976239734
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.975,305.7385833858326
+2025-11-22,1,wk inc rsv hosp,2025-11-29,36,quantile,0.99,375.29752707527143
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.2,0.4268172681726876
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.25,4.895441454414541
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.3,11.727312273122728
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.35,16.72994779947799
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.4,21.264989649896513
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.45,23.920376203762032
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.5,26
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.55,28.727312273122728
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.6,32.23753937539374
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.65,36.78461434614346
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.7,43.474505745057414
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.75,51.55414304143041
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.8,61.92898628986292
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.85,77.45522605226049
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.9,105.47847778477785
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.95,152.95242852428507
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.975,200.50968709687078
+2025-11-22,1,wk inc rsv hosp,2025-11-29,37,quantile,0.99,231.42153331533297
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.4,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.45,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.5,2.6250262502358623e-4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.55,0.6007410074100719
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.6,0.6007410074100719
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.65,0.6141811418114216
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.7,1.6007410074100719
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.75,2.563210632106319
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.8,3.600741007410072
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.85,4.600741007410072
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.9,6.859406594065949
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.95,12.287620376203748
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.975,17.12256622566226
+2025-11-22,1,wk inc rsv hosp,2025-11-29,38,quantile,0.99,18.91008400084003
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.2,4.209444094440947
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.25,13
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.3,19.119962199621995
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.35,23.637393873938734
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.4,26.171703717037193
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.45,29
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.5,31
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.55,33.67202022020221
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.6,36.28939489394893
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.65,39.68505985059851
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.7,44.41368913689135
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.75,52.0419854198542
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.8,64.96197161971622
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.85,84.14995199952017
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.9,107.13822038220385
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.95,160.8950544505449
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.975,212.75555605556033
+2025-11-22,1,wk inc rsv hosp,2025-11-29,39,quantile,0.99,227.42091410914085
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.4,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.45,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.5,2.1000210002064534e-4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.55,0.43743437434374854
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.6,1.8679986799867936
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.65,3.928941289412898
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.7,6.8918759187591885
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.75,9.975212252122525
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.8,14.16432964329644
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.85,16.43743437434375
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.9,24.678633786337848
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.95,33.774441244412444
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.975,41.797804728047154
+2025-11-22,1,wk inc rsv hosp,2025-11-29,40,quantile,0.99,50.85414304143046
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.35,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.4,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.45,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.5,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.55,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.6,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.65,6.7202592025920245
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.7,8.995124951249498
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.75,13.39391143911439
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.8,19
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.85,26
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.9,40.17867278672788
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.95,51
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.975,59.77536375363751
+2025-11-22,1,wk inc rsv hosp,2025-11-29,41,quantile,0.99,68.37138001380013
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.15,10.118426184261832
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.2,25.40326403264033
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.25,42.092108421084205
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.3,63
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.35,76.8313833138331
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.4,85.87902679026791
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.45,92.70990909909099
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.5,99
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.55,106
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.6,112.86213662136618
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.65,122
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.7,138.0365493654936
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.75,158.3330783307833
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.8,174.71764317643178
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.85,194.30121651216504
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.9,224.12432424324248
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.95,306.1745702457018
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.975,399.8294145441457
+2025-11-22,1,wk inc rsv hosp,2025-11-29,42,quantile,0.99,494.0126040260392
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.35,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.4,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.45,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.5,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.55,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.6,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.65,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.7,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.75,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.8,6.896186961869615
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.85,8.932145321453223
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.9,13.266618666186657
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.95,18.16851468514685
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.975,27.771096210962067
+2025-11-22,1,wk inc rsv hosp,2025-11-29,44,quantile,0.99,33.43338823388232
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.05,0.32365973659737957
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.1,14.205949059490596
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.15,25
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.2,35
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.25,41
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.3,44.80854108541086
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.35,47.27064020640205
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.4,49.61942819428194
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.45,51.101461014610145
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.5,53
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.55,54.894922449224495
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.6,56.30246302463024
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.65,58.723929739297404
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.7,61.30549005490055
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.75,65
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.8,71
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.85,81.60958059580592
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.9,92
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.95,110.28096030960303
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.975,142.06019635196364
+2025-11-22,1,wk inc rsv hosp,2025-11-29,45,quantile,0.99,176.75266522665214
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.4,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.45,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.5,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.55,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.6,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.65,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.7,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.75,3.183099330993315
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.8,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.85,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.9,9.482176821768213
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.95,14
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.975,16.2570350703507
+2025-11-22,1,wk inc rsv hosp,2025-11-29,46,quantile,0.99,18.23458254582546
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.2,1.4954429544295436
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.25,5.000450004500045
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.3,9
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.35,11.079920799207988
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.4,13
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.45,14
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.5,15
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.55,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.6,17.742027420274194
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.65,19.05141301413014
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.7,21.952725527255275
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.75,26.816188161881612
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.8,31.409864098641
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.85,39.34658596585967
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.9,52.12738727387275
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.95,76.57551075510746
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.975,111.83094455944543
+2025-11-22,1,wk inc rsv hosp,2025-11-29,47,quantile,0.99,148.82646206462042
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.05,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.1,36.78806588065881
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.15,72.99617046170461
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.2,91.53441334413347
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.25,112.74213992139926
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.3,126.26461464614644
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.35,135
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.4,141.87558875588758
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.45,148.02366573665736
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.5,153
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.55,157.58010080100803
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.6,163.8317463174632
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.65,171
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.7,179.62027120271202
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.75,193.21864968649686
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.8,214.47390873908753
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.85,232.71010110101105
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.9,270.0411034110341
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.95,306.770766207662
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.975,358.3671781717816
+2025-11-22,1,wk inc rsv hosp,2025-11-29,48,quantile,0.99,479.9339312393098
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.4,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.45,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.5,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.55,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.6,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.65,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.7,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.75,7.90859658596586
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.8,12.758797587975893
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.85,21.795201452014506
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.9,35.18316083160837
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.95,51
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.975,56.242897428974274
+2025-11-22,1,wk inc rsv hosp,2025-11-29,49,quantile,0.99,63.671785317853185
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.4,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.45,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.5,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.55,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.6,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.65,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.7,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.75,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.8,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.85,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.9,6
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.95,8.768780187801871
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.975,11
+2025-11-22,1,wk inc rsv hosp,2025-11-29,50,quantile,0.99,12
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.15,3.394464944649463
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.2,9.615714157141571
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.25,14
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.3,17.03170131701317
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.35,19.838019380193792
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.4,21.89665496654967
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.45,23.434560345603458
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.5,25
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.55,27
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.6,28.599225992259914
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.65,30.702698526985273
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.7,33
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.75,36.560255602556026
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.8,41.76473764737648
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.85,50.08169381693811
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.9,63.891506915069186
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.95,96.82319473194723
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.975,144.55579080790775
+2025-11-22,1,wk inc rsv hosp,2025-11-29,51,quantile,0.99,163.28709207092044
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.25,0.9127591275912765
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.3,2.002730027300271
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.35,4
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.4,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.45,6.051327513275149
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.5,7
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.55,8.206273062730627
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.6,9.766867668676674
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.65,11.434435844358458
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.7,14.297248972489717
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.75,18.396843968439676
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.8,23
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.85,27.8372333723337
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.9,33.341583415834165
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.95,42.720614706147025
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.975,57.74790072900722
+2025-11-22,1,wk inc rsv hosp,2025-11-29,53,quantile,0.99,74.28992799927987
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.4,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.45,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.5,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.55,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.6,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.65,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.7,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.75,8.247329973299728
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.8,11.176371763717645
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.85,16
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.9,22.096450964509643
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.95,34.491865418653994
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.975,45
+2025-11-22,1,wk inc rsv hosp,2025-11-29,54,quantile,0.99,49
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.3,0.27259772597725984
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.35,1.2725977259772598
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.4,2.27259772597726
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.45,3.7415024150241543
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.5,5
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.55,6.27259772597726
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.6,8.27259772597726
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.65,9.670125701257021
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.7,12.126610266102656
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.75,15.309723097230986
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.8,20.96414664146643
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.85,29.122660726607258
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.9,36.331035310353116
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.95,43.9630591305909
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.975,52.96799642996423
+2025-11-22,1,wk inc rsv hosp,2025-11-29,55,quantile,0.99,68.00416614166141
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.1,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.15,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.2,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.25,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.3,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.35,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.4,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.45,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.5,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.55,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.6,1
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.65,2
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.7,3
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.75,4.266515165151652
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.8,7.119131191311922
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.85,8.880286802868024
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.9,11
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.95,15.617886178861767
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.975,18.929530045300446
+2025-11-22,1,wk inc rsv hosp,2025-11-29,56,quantile,0.99,22.75895058950584
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.025,3.8636111361113694
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.05,46.628891788917926
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.1,74.38622086220862
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.15,94.15760807608075
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.2,105.50262502625029
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.25,116
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.3,122.33483034830348
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.35,126.71137911379114
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.4,130
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.45,133
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.5,135
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.55,137
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.6,140
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.65,143.210087600876
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.7,147.58095880958808
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.75,153.96105961059612
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.8,164.17712177121774
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.85,176
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.9,195.8919929199293
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.95,224.7774427744275
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.975,279.61135136351317
+2025-11-22,1,wk inc rsv hosp,2025-11-29,72,quantile,0.99,346.65898418984176
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.01,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.025,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.05,0
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.1,60.852020520205045
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.15,361.05610356103534
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.2,602.3278072780727
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.25,823.8095505955056
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.3,1035.1595205952053
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.35,1195.245672456724
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.4,1312.7043770437704
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.45,1382.1374148741484
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.5,1432
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.55,1483.5686811868118
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.6,1552.1514055140549
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.65,1677.2862493624934
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.7,1837.0382923829234
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.75,2059.7461824618244
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.8,2295.306165061653
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.85,2540.142252422524
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.9,2898.9323853238543
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.95,3480.088319383189
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.975,4334.577319773192
+2025-11-22,1,wk inc rsv hosp,2025-11-29,US,quantile,0.99,5014.477363273633
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.1,7.236141361413617
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.15,12.894424444244445
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.2,17.06917469174692
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.25,20.6870668706687
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.3,23.226238262382616
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.35,25.59074040740407
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.4,27.536531365313657
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.45,29.177447274472748
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.5,31
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.55,33
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.6,34.67069870698707
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.65,36.55616956169564
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.7,38.88812288122882
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.75,41.4331518315183
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.8,45
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.85,49.12207722077201
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.9,55
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.95,64.72802778027781
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.975,73.93757012570127
+2025-11-22,2,wk inc rsv hosp,2025-12-06,01,quantile,0.99,84.47147931479311
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.4,0.2745927459274604
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.45,1.2745927459274604
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.5,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.55,2.6957339573395798
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.6,4.112423124231239
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.65,5.443497434974357
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.7,7.27459274592746
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.75,9.14119641196412
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.8,10.633798337983386
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.85,12.960884108841087
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.9,15.700747007470069
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.95,19.27459274592746
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.975,23.365732157321563
+2025-11-22,2,wk inc rsv hosp,2025-12-06,02,quantile,0.99,27.716540065400608
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.45,0.7982929829298193
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.5,4
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.55,7.798292982929819
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.6,11.479383793837915
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.65,16.79829298292982
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.7,24.396417964179598
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.75,36.686489364893646
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.8,50.26686766867675
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.85,69.41632766327662
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.9,85.31540815408151
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.95,106.15018000179991
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.975,128.61423289232872
+2025-11-22,2,wk inc rsv hosp,2025-12-06,04,quantile,0.99,162.1611460114599
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.3,0.4479494794947918
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.35,2.44554195541955
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.4,3.8359913599135975
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.45,5.447949479494792
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.5,7
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.55,8.447949479494792
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.6,10.447949479494792
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.65,12.447949479494792
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.7,14.447949479494792
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.75,16.877006270062708
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.8,19.63576335763358
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.85,22.90545105451054
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.9,27.060420604206058
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.95,33.126503765037654
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.975,38.597458974589735
+2025-11-22,2,wk inc rsv hosp,2025-12-06,05,quantile,0.99,45.60618666186662
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.2,0.9062340623406413
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.25,13.712349623496268
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.3,26.004065040650435
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.35,38.202713527135195
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.4,48.46561365613658
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.45,57.388818888188894
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.5,65
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.55,72.94701347013468
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.6,82.70540005400056
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.65,94.3343503435034
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.7,106.6895268952691
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.75,119.55398553985543
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.8,135.43777337773383
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.85,157.1292457924579
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.9,180.6987099870999
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.95,214.55092850928514
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.975,245.65516605166056
+2025-11-22,2,wk inc rsv hosp,2025-12-06,06,quantile,0.99,285.5447580475804
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.4,1.8199231992319937
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.45,4.044313443134435
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.5,6
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.55,8.819923199231994
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.6,12.223925239252402
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.65,16.915522155221545
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.7,23.75813458134577
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.75,29.819923199231994
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.8,34.819923199231994
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.85,41.05566555665555
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.9,50.424366243662504
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.95,65.17899228992287
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.975,77.98207707077083
+2025-11-22,2,wk inc rsv hosp,2025-12-06,08,quantile,0.99,93.1681234812344
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.35,0.3524885248852456
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.4,1.5889328893288885
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.45,3.0751522515225096
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.5,4
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.55,5.352488524885246
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.6,6.5531245312453095
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.65,8.508503585035854
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.7,10.732856328563278
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.75,13.352488524885246
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.8,18.52959829598296
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.85,32.70280052800529
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.9,44.54930249302487
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.95,51.54028890288903
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.975,57.352488524885246
+2025-11-22,2,wk inc rsv hosp,2025-12-06,09,quantile,0.99,73.89340773407672
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.15,0.6922689226892235
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.2,3.178141781417814
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.25,5.614631146311464
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.3,7.9129901299012975
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.35,9
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.4,10.330207302073024
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.45,11
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.5,12
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.55,13
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.6,14
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.65,15
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.7,16.65392553925539
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.75,19
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.8,21
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.85,25.353340533405337
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.9,32.38715987159874
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.95,49.16559715597157
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.975,68.59266792667925
+2025-11-22,2,wk inc rsv hosp,2025-12-06,10,quantile,0.99,88.75060240602416
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.3,0.02058020580205877
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.35,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.4,1.0791047910479141
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.45,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.5,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.55,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.6,3
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.65,3
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.7,4
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.75,4.2231272312723185
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.8,5.2317103171031745
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.85,6.7217142171421616
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.9,9.442789427894287
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.95,15.326959769597668
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.975,18.917952929529285
+2025-11-22,2,wk inc rsv hosp,2025-12-06,11,quantile,0.99,21.190458404584053
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.01,143.63456934569342
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.025,178.05390753907537
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.05,210.2844523445234
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.1,242.609969099691
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.15,264.28977439774394
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.2,280.96810368103684
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.25,294.42464674646743
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.3,304.92497524975244
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.35,314.1516725167251
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.4,322.70759907599074
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.45,330.36625716257157
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.5,338
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.55,345.55212402124016
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.6,353.27850478504786
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.65,361.820710707107
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.7,371.01045810458095
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.75,381.91764917649175
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.8,395.29628896288966
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.85,411.960641106411
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.9,433.63996939969394
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.95,465.78835988359833
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.975,497.2021225212252
+2025-11-22,2,wk inc rsv hosp,2025-12-06,12,quantile,0.99,532.0671331713312
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.1,29.278435784357857
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.15,52.58894788947889
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.2,66.53104731047311
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.25,75.17712177121771
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.3,82
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.35,87.11232412324124
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.4,91.1789997899979
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.45,94.96171661716616
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.5,98
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.55,101.15334503345036
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.6,104.82956829568295
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.65,108.72280472804727
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.7,113.84079740797408
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.75,120.7740077400774
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.8,129.36962169621702
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.85,143.7063930639306
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.9,167.6618006180063
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.95,202.57023820238197
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.975,235.54049215492148
+2025-11-22,2,wk inc rsv hosp,2025-12-06,13,quantile,0.99,269.8647013470127
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.15,0.4208502085020829
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.2,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.25,3.7029520295202945
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.3,5
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.35,6
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.4,7
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.45,8
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.5,9
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.55,10
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.6,11
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.65,12
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.7,13.144829448294482
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.75,14.761962619626193
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.8,16
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.85,18
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.9,20.59212792127925
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.95,25.91727717277169
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.975,32.47663276632768
+2025-11-22,2,wk inc rsv hosp,2025-12-06,15,quantile,0.99,40.113536135361315
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.45,0.34509345093450783
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.5,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.55,1.6199036990369837
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.6,3.345093450934508
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.65,5.314680646806467
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.7,7.345093450934508
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.75,9.345093450934508
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.8,11.919503195031954
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.85,15.011455614556136
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.9,19.40860408604086
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.95,25.69831398313983
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.975,31.409666096660963
+2025-11-22,2,wk inc rsv hosp,2025-12-06,16,quantile,0.99,37.55027660276595
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.35,1.5502925029250547
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.4,7.201179011790144
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.45,12.254597545975471
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.5,17
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.55,22.25459754597547
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.6,29.089841898418946
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.65,37.75453904539049
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.7,49.08232682326817
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.75,62.92526925269253
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.8,79.57125071250714
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.85,99.1283112831128
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.9,125.32550025500265
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.95,173.99065490654877
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.975,214.68659511595112
+2025-11-22,2,wk inc rsv hosp,2025-12-06,17,quantile,0.99,250.42762907629057
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.3,1.8654666546665382
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.35,5.898921489214883
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.4,9.369057690576916
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.45,12.22882428824288
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.5,15
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.55,17.713333633336347
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.6,21.080760807608044
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.65,25.940111901119018
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.7,32.03335733357325
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.75,40.76836018360183
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.8,50.09066090660907
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.85,61.04851348513481
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.9,75.62579125791261
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.95,102.68549635496383
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.975,123.33666336663364
+2025-11-22,2,wk inc rsv hosp,2025-12-06,18,quantile,0.99,143.5649737497373
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.45,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.5,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.55,2.441724417244174
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.6,5.061818618186184
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.65,8.674387243872435
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.7,13.215618156181552
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.75,17.10995859958599
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.8,22.630588305882988
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.85,30.422855728557252
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.9,54.860273602736065
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.95,87.46163711637107
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.975,100.3943734437344
+2025-11-22,2,wk inc rsv hosp,2025-12-06,19,quantile,0.99,113.87933129331284
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.4,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.45,2.5417109171091816
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.5,4
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.55,5.064284642846428
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.6,7.0743407434074275
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.65,9.74842498424984
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.7,12.187078870788708
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.75,15.58685086850869
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.8,20.22809228092281
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.85,25.957294572945706
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.9,32.7939879398794
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.95,41.24005190051895
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.975,48.9043320433204
+2025-11-22,2,wk inc rsv hosp,2025-12-06,20,quantile,0.99,59.79960309603091
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.3,2.0730807308073125
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.35,5.284741847418477
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.4,8.073080730807312
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.45,10.584969849698503
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.5,13
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.55,15.073080730807312
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.6,18.073080730807312
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.65,21.390801908019085
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.7,25.65208052080519
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.75,31.2749152491525
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.8,37.07308073080731
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.85,45.055053550535504
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.9,57.66297962979642
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.95,91.76224612246101
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.975,131.59743647436468
+2025-11-22,2,wk inc rsv hosp,2025-12-06,21,quantile,0.99,148.62168331683318
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.2,4.197719977199767
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.25,9.989109891098911
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.3,14.223469234692345
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.35,17.48346233462334
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.4,20
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.45,22
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.5,24
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.55,26.139640896408963
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.6,28.61186211862118
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.65,31.061050610506108
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.7,34.59848798487985
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.75,39.460729607296074
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.8,46.28239282392827
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.85,55.78931539315393
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.9,69.03554135541356
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.95,93.74036240362395
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.975,105.41729292292922
+2025-11-22,2,wk inc rsv hosp,2025-12-06,22,quantile,0.99,120.29351573515734
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.45,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.5,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.55,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.6,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.65,1.6099825998259973
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.7,2.484654846548466
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.75,3.5228977289772843
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.8,4.898010980109808
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.85,6
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.9,7
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.95,9.06976869768695
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.975,11.546301713017128
+2025-11-22,2,wk inc rsv hosp,2025-12-06,23,quantile,0.99,14.052296522965221
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.15,0.8554420544205414
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.2,7.002916029160292
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.25,11.959049590495905
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.3,15.38892988929889
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.35,18.534848348483475
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.4,21.026580265802657
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.45,23.878987789877904
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.5,26
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.55,28.461472114721154
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.6,31
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.65,34
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.7,37.03872738727385
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.75,41.056618066180654
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.8,46.66942669426695
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.85,55.28290282902827
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.9,70
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.95,91
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.975,111.87196621966201
+2025-11-22,2,wk inc rsv hosp,2025-12-06,24,quantile,0.99,130.6139573395734
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.3,1.501785017850171
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.35,5.8028830288302835
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.4,9.802883028830284
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.45,13.60190351903519
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.5,17
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.55,20.802883028830284
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.6,24.802883028830284
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.65,29.602649026490255
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.7,35.17290672906731
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.75,42.405326553265525
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.8,52.42747727477281
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.85,67.96626166261657
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.9,89.11510815108163
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.95,131.51507965079634
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.975,188.62237647376534
+2025-11-22,2,wk inc rsv hosp,2025-12-06,25,quantile,0.99,246.2058803588027
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.4,0.3185641856418582
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.45,4.748439984399848
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.5,8
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.55,15.548622986229862
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.6,22.68726187261876
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.65,31.363263132631367
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.7,42.54456544565444
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.75,52.78620286202866
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.8,67.21536915369157
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.85,84.74182491824916
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.9,103.44681846818466
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.95,142.02806828068273
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.975,183.80154351543504
+2025-11-22,2,wk inc rsv hosp,2025-12-06,26,quantile,0.99,229.51464254642465
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.25,0.8862913629136262
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.3,5.035304353043537
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.35,9.745559955599546
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.4,13.639396393963942
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.45,16.253399033990345
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.5,18
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.55,20.06738817388176
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.6,23.03034830348303
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.65,27.368030180301822
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.7,32.11002610026098
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.75,37.1368388683887
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.8,41.91306513065132
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.85,46.372977229772296
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.9,54.08689586895871
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.95,67.83298532985327
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.975,79.11588290882901
+2025-11-22,2,wk inc rsv hosp,2025-12-06,27,quantile,0.99,92.58161251612509
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.35,1.315619656196558
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.4,2.379563795637953
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.45,3.4038895388953874
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.5,5
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.55,6.379563795637953
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.6,7.693906939069386
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.65,9.420886208862083
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.7,11.891857918579177
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.75,14.578488284882848
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.8,17.867350673506746
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.85,21.379563795637953
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.9,25.733135331353317
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.95,33.185404854048535
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.975,39.030994809948005
+2025-11-22,2,wk inc rsv hosp,2025-12-06,28,quantile,0.99,46.379592595925935
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.4,0.06680466804668755
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.45,2.6842933429334357
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.5,5
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.55,8
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.6,12
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.65,16.46257612576128
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.7,21.814940149401437
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.75,27.226052260522618
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.8,33.00543605436055
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.85,41.02679176791766
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.9,54.0808028080281
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.95,74.22789877898784
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.975,87.66625866258661
+2025-11-22,2,wk inc rsv hosp,2025-12-06,29,quantile,0.99,105.59108211082113
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.45,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.5,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.55,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.6,1.747043470434688
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.65,3
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.7,4.883655836558371
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.75,7
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.8,9
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.85,11.71325563255633
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.9,15.598106981069828
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.95,24.547314973149707
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.975,32
+2025-11-22,2,wk inc rsv hosp,2025-12-06,30,quantile,0.99,36.980634506345005
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.3,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.35,3
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.4,4
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.45,5
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.5,6
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.55,7
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.6,8.251672516725165
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.65,10
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.7,11.592190921909207
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.75,14
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.8,16.520361203612044
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.85,20.475924759247576
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.9,26.799972999729995
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.95,33.24344043440437
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.975,38.79507545075451
+2025-11-22,2,wk inc rsv hosp,2025-12-06,31,quantile,0.99,46.215109351093496
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.4,0.9321843218432164
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.45,1.9321843218432164
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.5,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.55,2.9321843218432164
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.6,4.3971589715896995
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.65,6.401480514805142
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.7,8.932184321843216
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.75,11.932184321843216
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.8,15.932184321843216
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.85,20.316245162451587
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.9,25.46535865358654
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.95,33.89448444484442
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.975,42.963575135751306
+2025-11-22,2,wk inc rsv hosp,2025-12-06,32,quantile,0.99,51.218220082200624
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.3,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.35,1.0888608886088846
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.4,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.45,3
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.5,3
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.55,4
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.6,4.115831158311579
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.65,5
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.7,6.0604476044760345
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.75,8
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.8,11
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.85,13.56450064500645
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.9,15.946635466354667
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.95,18.638565385653873
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.975,22.062123121231192
+2025-11-22,2,wk inc rsv hosp,2025-12-06,33,quantile,0.99,27.428935289352886
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.2,3.9941769417694193
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.25,14.932274322743226
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.3,24.49368793687935
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.35,31.412378123781238
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.4,36.44880148801494
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.45,40.87509825098252
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.5,45
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.55,49.2409609096091
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.6,53.54680046800465
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.65,59.231830318303196
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.7,66.5787987879879
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.75,77.64499144991453
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.8,90.8030030300303
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.85,106.78850838508379
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.9,130.66719167191658
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.95,159.4024495244951
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.975,176.24000915009145
+2025-11-22,2,wk inc rsv hosp,2025-12-06,34,quantile,0.99,210.53803978039758
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.4,0.4357993579935773
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.45,1.4357993579935773
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.5,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.55,2.4573485734857385
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.6,3.718912189121874
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.65,5.435799357993577
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.7,7.435799357993577
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.75,11.435799357993577
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.8,17.317166171661665
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.85,25.498271982719828
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.9,30.199177991779923
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.95,42.08781837818372
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.975,57.26188386883864
+2025-11-22,2,wk inc rsv hosp,2025-12-06,35,quantile,0.99,71.71822668226669
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.2,0.9906699066990831
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.25,20.96797467974679
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.3,42.63042630426304
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.35,58.71062310623106
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.4,70.46234062340623
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.45,79.69411394113942
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.5,88
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.55,96.42561725617256
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.6,106.25131851318511
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.65,119.3167341673417
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.7,137.01263612636114
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.75,160.5581480814808
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.8,184.00528005280046
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.85,214.01906369063684
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.9,248.58179881798821
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.95,297.8981384813842
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.975,356.47247397473944
+2025-11-22,2,wk inc rsv hosp,2025-12-06,36,quantile,0.99,415.8209570095694
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.3,3.2508865088650873
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.35,10.471339213392117
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.4,16.41942219422196
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.45,21.621516215162153
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.5,26
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.55,30.983627336273372
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.6,36.93129331293311
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.65,44.585404854048576
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.7,53.10138901389014
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.75,63.987362373623704
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.8,79.13246332463325
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.85,102.06113911139104
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.9,132.00924609246093
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.95,182.70798157981562
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.975,222.12812753127525
+2025-11-22,2,wk inc rsv hosp,2025-12-06,37,quantile,0.99,257.0244778447781
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.45,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.5,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.55,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.6,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.65,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.7,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.75,3
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.8,4.302775027750278
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.85,6.145538955389556
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.9,10.017283172831746
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.95,14.68212432124317
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.975,18
+2025-11-22,2,wk inc rsv hosp,2025-12-06,38,quantile,0.99,21.4356961569616
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.25,2.1525665256652715
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.3,10.42099720997209
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.35,17.2733657336573
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.4,22.72815828158283
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.45,27.004785047850476
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.5,31
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.55,35.004785047850476
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.6,39.71872018720185
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.65,45.89428044280443
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.7,54.81348213482126
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.75,67.17784927849277
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.8,83.38836888368893
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.85,102.3488989889899
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.9,129.96492364923645
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.95,196.02237422374225
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.975,222.63040605406061
+2025-11-22,2,wk inc rsv hosp,2025-12-06,39,quantile,0.99,259.47490984909786
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.45,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.5,1.5000150000332724e-5
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.55,1.762427624276242
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.6,4.249902499024973
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.65,7.223631236312367
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.7,10.499306993069919
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.75,13.762427624276242
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.8,16.907701077010767
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.85,22.808304083040785
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.9,29.69058890588908
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.95,39.59713197131975
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.975,48.656350313503125
+2025-11-22,2,wk inc rsv hosp,2025-12-06,40,quantile,0.99,59.74874358743589
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.4,0.21969219692197134
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.45,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.5,3
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.55,4.344427444274443
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.6,6.336405364053633
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.65,9.376517265172664
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.7,14.193729937299295
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.75,19
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.8,25.305349053490655
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.85,35.88863288632881
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.9,45.9626436264363
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.95,57.19939099390983
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.975,67.08833138331381
+2025-11-22,2,wk inc rsv hosp,2025-12-06,41,quantile,0.99,84.29466174661744
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.2,8.138577385773896
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.25,25.716167161671645
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.3,42.98557585575858
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.35,61.724123241232434
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.4,76.76005760057606
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.45,88.33891338913392
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.5,99
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.55,109.4275222752228
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.6,121.66550265502649
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.65,138.48351483514836
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.7,157.45900159001587
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.75,175.63735637356348
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.8,196.05905259052594
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.85,224.15646056460562
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.9,272.5862478624787
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.95,367.21906069060674
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.975,451.92383223832206
+2025-11-22,2,wk inc rsv hosp,2025-12-06,42,quantile,0.99,537.7970773707726
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.4,0.6041610416104177
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.45,1.6041610416104177
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.5,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.55,2.6041610416104177
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.6,3.6041610416104177
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.65,4.604161041610418
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.7,5.604161041610418
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.75,6.8304908049080595
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.8,8.901554015540173
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.85,11.975563255632538
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.9,15.676674766747674
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.95,23.200537005369924
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.975,30.920916959169556
+2025-11-22,2,wk inc rsv hosp,2025-12-06,44,quantile,0.99,36.150999909999044
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.1,5.46948669486695
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.15,16.030312303123036
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.2,25.42077820778209
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.25,33.672734227342275
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.3,39.710296102961024
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.35,44
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.4,47.289424894248945
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.45,50.19338643386434
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.5,53
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.55,55.84815048150482
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.6,58.78481384813848
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.65,62
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.7,66.49509495094948
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.75,72.91968169681697
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.8,81.25232652326518
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.85,90.56376413764134
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.9,102.56503465034653
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.95,129.34946449464485
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.975,160.5856936069362
+2025-11-22,2,wk inc rsv hosp,2025-12-06,45,quantile,0.99,189.05501065010654
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.45,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.5,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.55,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.6,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.65,2.492459424594256
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.7,4
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.75,4.907111571115726
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.8,6.41512015120151
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.85,8.943560435604347
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.9,12.389523895238938
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.95,15.910174601746002
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.975,18.276832268322632
+2025-11-22,2,wk inc rsv hosp,2025-12-06,46,quantile,0.99,22.59893498934988
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.25,0.5192451924519261
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.3,4.303363033630329
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.35,8.09875498754987
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.4,10.810980109801104
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.45,13.181854318543195
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.5,15
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.55,16.8559145591456
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.6,19.519245192451926
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.65,22.756178561785624
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.7,27.473215732157286
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.75,32.30049050490505
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.8,40.14043740437407
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.85,50.35982659826596
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.9,64.92666126661277
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.95,96.66469714697149
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.975,131.6797505475048
+2025-11-22,2,wk inc rsv hosp,2025-12-06,47,quantile,0.99,160.9271070710702
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.1,12.994536945369433
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.15,45.460137101371004
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.2,72.11679116791166
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.25,91.42658926589263
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.3,108.98829388293882
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.35,123.81099510995107
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.4,135.35291752917527
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.45,144.32071970719704
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.5,153
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.55,161.43834338343387
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.6,170.6526085260852
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.65,182.0949269492695
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.7,196.4955119551195
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.75,214.88593885938857
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.8,233.29496894968952
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.85,260.3755122551225
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.9,294.5075960759608
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.95,344.7868073680734
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.975,421.3778807788101
+2025-11-22,2,wk inc rsv hosp,2025-12-06,48,quantile,0.99,540.3011238112381
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.45,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.5,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.55,1.9792097920979188
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.6,4
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.65,5.752575525755262
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.7,9.258722587225808
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.75,13.69824198241983
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.8,21.67512675126755
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.85,31.297637476374828
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.9,45.44141841418416
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.95,54
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.975,62.3417806678066
+2025-11-22,2,wk inc rsv hosp,2025-12-06,49,quantile,0.99,79.96777517775165
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.45,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.5,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.55,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.6,0.713707137071365
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.65,1
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.7,2
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.75,2.872266222662221
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.8,3.4052200522005327
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.85,5
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.9,7
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.95,9.432491824918271
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.975,11
+2025-11-22,2,wk inc rsv hosp,2025-12-06,50,quantile,0.99,13.488937089370864
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.2,2.7945579455794656
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.25,8.53468034680347
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.3,13.084243842438418
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.35,16.82561425614254
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.4,19.826958269582697
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.45,22.606834068340696
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.5,25
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.55,27.826958269582697
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.6,30.6093300933009
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.65,33.8269582695827
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.7,37.8269582695827
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.75,43.23389733897338
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.8,50.8269582695827
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.85,61.506981069810685
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.9,76.75488554885547
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.95,129.0949104491043
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.975,155.70069975699755
+2025-11-22,2,wk inc rsv hosp,2025-12-06,51,quantile,0.99,173.27582275822772
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.35,1.1627366273662718
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.4,3.2757687576875787
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.45,5
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.5,7
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.55,9
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.6,11
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.65,14.208586085860858
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.7,18.055851558515577
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.75,22.222827228272283
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.8,26.694962949629502
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.85,31.77091920919198
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.9,38.202526025260255
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.95,53.09511295112932
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.975,67.04062715627136
+2025-11-22,2,wk inc rsv hosp,2025-12-06,53,quantile,0.99,81.15920799207987
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.45,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.5,1.050010500094345e-4
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.55,1.1924819248192478
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.6,3.1924819248192478
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.65,5.540966909669097
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.7,8.192481924819248
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.75,11.472654726547272
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.8,15.832136321363237
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.85,20.96869918699185
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.9,27.596915969159653
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.95,42.17727027270269
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.975,48.19248192481925
+2025-11-22,2,wk inc rsv hosp,2025-12-06,54,quantile,0.99,58.840120901208984
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.4,1.0326253262532639
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.45,2.9912609126091216
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.5,5
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.55,7.296102961029593
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.6,9.62882128821288
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.65,12.56850118501185
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.7,16.48263882638826
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.75,21.752242522425234
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.8,28.03652536525367
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.85,34.36200912009117
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.9,40.83071730717308
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.95,51.870896708967024
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.975,64.69566870668706
+2025-11-22,2,wk inc rsv hosp,2025-12-06,55,quantile,0.99,76.85605946059441
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.15,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.2,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.25,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.3,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.35,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.4,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.45,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.5,9.000090000910177e-5
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.55,0.4746647466474627
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.6,1.779101791017914
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.65,2.915688656886572
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.7,4.527072270722694
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.75,6.744082440824407
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.8,8.474664746647463
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.85,10.403154531545308
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.9,12.951561515615138
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.95,17.9496189961899
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.975,21.65061200612005
+2025-11-22,2,wk inc rsv hosp,2025-12-06,56,quantile,0.99,26.6564245642456
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.05,17.303235532355338
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.1,59.63709237092373
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.15,77.91421564215636
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.2,93.15762157621577
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.25,104.21328713287134
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.3,114
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.35,121
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.4,126.59950199501995
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.45,131
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.5,135
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.55,138.96363963639635
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.6,143.41867818678185
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.65,149
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.7,156
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.75,165.5967434674347
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.8,176.7330453304533
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.85,192.49381693816932
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.9,210.8669096690967
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.95,256.5515525155254
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.975,313.68128131281327
+2025-11-22,2,wk inc rsv hosp,2025-12-06,72,quantile,0.99,368.0880571805711
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.01,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.025,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.05,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.1,0
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.15,77.74381543815407
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.2,355.65091350913525
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.25,592.3487684876844
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.3,813.0257312573128
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.35,1016.776100261003
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.4,1185.9403204032049
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.45,1330.1570875708755
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.5,1432
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.55,1539.6902049020491
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.6,1682.870611706117
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.65,1853.609004590046
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.7,2067.4996789967895
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.75,2297.7128446284455
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.8,2545.1774487744897
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.85,2853.6594125941256
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.9,3285.4772807728104
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.95,4077.5254057540424
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.975,4829.729023790237
+2025-11-22,2,wk inc rsv hosp,2025-12-06,US,quantile,0.99,5485.319731497311
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.1,3.0458044580445858
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.15,9.397818978189786
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.2,14.055956559565605
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.25,18
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.3,21.109360093600934
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.35,24
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.4,26.532649326493264
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.45,29
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.5,31
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.55,33.164379143791436
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.6,35.61011610116101
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.65,38
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.7,40.919782197821974
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.75,44.022125221252224
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.8,48
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.85,52.71093360933608
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.9,59.32037920379205
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.95,69.82696726967266
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.975,79.48159106591064
+2025-11-22,3,wk inc rsv hosp,2025-12-13,01,quantile,0.99,90.73525155251528
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.45,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.5,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.55,3
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.6,4.821804218042186
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.65,6.436006360063612
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.7,8
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.75,10
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.8,12
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.85,14.489541895418956
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.9,17.34236642366424
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.95,22.05103051030511
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.975,26.355689556895555
+2025-11-22,3,wk inc rsv hosp,2025-12-13,02,quantile,0.99,31.125459754597493
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.5,4
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.55,8.878105781057794
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.6,14.811601116011143
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.65,22.565099150991504
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.7,33.34676446764476
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.75,45.865216152161594
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.8,61.59350493504936
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.85,77.22659826598267
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.9,93.49410494104956
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.95,119.61207662076619
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.975,147.05993759937596
+2025-11-22,3,wk inc rsv hosp,2025-12-13,04,quantile,0.99,179.84268292682893
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.35,1.0685356853568564
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.4,3.0685356853568564
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.45,5.037635376353769
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.5,7
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.55,9.014772147721478
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.6,11.068535685356856
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.65,13.157849578495789
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.7,15.75532655326553
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.75,18.431104311043093
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.8,21.51603816038162
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.85,25.173401734017347
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.9,29.891803918039184
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.95,36.98040680406797
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.975,43.398120481204806
+2025-11-22,3,wk inc rsv hosp,2025-12-13,05,quantile,0.99,50.92426784267844
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.25,3.148463984639834
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.3,17.059028590285862
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.35,30.721975219752146
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.4,43.173635736357355
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.45,54.70755107551075
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.5,65
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.55,75.93577685776856
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.6,88.27763477634772
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.65,101.20450604506054
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.7,114.7464434644346
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.75,130.74246242462422
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.8,149.4579545795458
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.85,170.28727387273867
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.9,196.311721117211
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.95,235.9838823388233
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.975,273.6662796627965
+2025-11-22,3,wk inc rsv hosp,2025-12-13,06,quantile,0.99,318.4518096180963
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.45,2.8588785887858865
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.5,6
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.55,9.858878588785887
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.6,14.7860678606786
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.65,20.76765517655179
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.7,26.858878588785885
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.75,32.4661446614466
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.8,38.23448234482342
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.85,46.39411844118438
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.9,57.29410194101942
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.95,73.30212702127015
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.975,87.62352323523237
+2025-11-22,3,wk inc rsv hosp,2025-12-13,08,quantile,0.99,105.49615366153664
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.4,0.8876488764887684
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.45,2.3021840218402407
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.5,4
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.55,5.904063540635415
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.6,7.948177481774806
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.65,10.125821258212582
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.7,13.011271112711123
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.75,17.813810638106364
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.8,27.66970869708704
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.85,39.56407014070139
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.9,47.18642486424866
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.95,55.1497374973749
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.975,64.97625551255504
+2025-11-22,3,wk inc rsv hosp,2025-12-13,09,quantile,0.99,89.49195571955718
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.2,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.25,3.8622536225362265
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.3,6
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.35,8
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.4,9.901845018450194
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.45,11
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.5,12
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.55,13
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.6,14.611838118381183
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.65,16.212633126331273
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.7,18.53422434224344
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.75,21
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.8,24.191161911619133
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.85,29.594536945369462
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.9,38.131767317673194
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.95,57.172252722527205
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.975,76.85278852788497
+2025-11-22,3,wk inc rsv hosp,2025-12-13,10,quantile,0.99,93.7407803078031
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.35,0.8178651786517859
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.4,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.45,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.5,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.55,2.806208562085624
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.6,3
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.65,4
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.7,4.200738007380067
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.75,5.0691806918069275
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.8,6.304503045030419
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.85,8.151051510515103
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.9,11.83871538715384
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.95,17.060990609906032
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.975,19.91179911799118
+2025-11-22,3,wk inc rsv hosp,2025-12-13,11,quantile,0.99,23.166333963339618
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.01,118.55470284702847
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.025,157.41532940329412
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.05,190.95459004590046
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.1,227.19716497164973
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.15,251.52581225812258
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.2,269.80070200702005
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.25,284.67644676446764
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.3,297.26060660606606
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.35,308.76039210392105
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.4,318.90147901479014
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.45,328.59338343383433
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.5,338
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.55,347.17232772327725
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.6,357.1859718597186
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.65,367.4243092430924
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.7,378.6976899768997
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.75,391.25973509735104
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.8,406.2438424384244
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.85,424.3137356373563
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.9,448.15942459424593
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.95,485.2733927339274
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.975,518.9952427024272
+2025-11-22,3,wk inc rsv hosp,2025-12-13,12,quantile,0.99,558.6618963189627
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.1,16.84511445114452
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.15,39.44947799477995
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.2,56.35841958419584
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.25,68
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.3,76.39852698526984
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.35,83.13082830828307
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.4,88.80230402304024
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.45,93.53796387963874
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.5,98
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.55,102.48679836798368
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.6,107.0941889418894
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.65,112.75790057900582
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.7,119.7010560105601
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.75,128.01318513185132
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.8,139.91262712627133
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.85,157.39105241052408
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.9,181.0674016740168
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.95,217.65392253922516
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.975,250.94251492514874
+2025-11-22,3,wk inc rsv hosp,2025-12-13,13,quantile,0.99,285.283561935619
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.2,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.25,2.4422644226442243
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.3,4
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.35,5.187183871838717
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.4,6.750373503735036
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.45,8
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.5,9
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.55,10.142699426994273
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.6,11.589391893918936
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.65,13
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.7,14.013848138481393
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.75,15.899468994689945
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.8,17.590087900879013
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.85,19.88350883508835
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.9,23
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.95,29.15217052170511
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.975,35.814724147241364
+2025-11-22,3,wk inc rsv hosp,2025-12-13,15,quantile,0.99,43.1834119341193
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.5,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.55,2.3178936789367888
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.6,4.241814418144189
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.65,6.320200702007037
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.7,8.749482494824944
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.75,11
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.8,13.896678966789665
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.85,17.563483634836334
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.9,22.22433324333245
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.95,29.123767737677365
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.975,35.00126001260012
+2025-11-22,3,wk inc rsv hosp,2025-12-13,16,quantile,0.99,42.91582755827558
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.4,2.8027030270302546
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.45,10.042114421144293
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.5,17
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.55,24.956334563345624
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.6,34.53979839798397
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.65,45.782896828968276
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.7,59.21224612246118
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.75,74.86136111361097
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.8,92.31994419944198
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.85,113.99558395583927
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.9,142.65902559025582
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.95,195.60295352953526
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.975,232.15828083280903
+2025-11-22,3,wk inc rsv hosp,2025-12-13,17,quantile,0.99,282.3455080550805
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.35,2.38909939099387
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.4,7.0740617406173865
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.45,11.350154501544992
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.5,15
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.55,19.387059370593683
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.6,24.532190321903197
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.65,30.657504575045728
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.7,38.569540695406886
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.75,47.53676536765367
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.8,57.32292022920237
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.85,69.70842108421078
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.9,85.79193891938932
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.95,114.14560345603455
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.975,133.42241097410957
+2025-11-22,3,wk inc rsv hosp,2025-12-13,18,quantile,0.99,161.12739417394164
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.5,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.55,3.9436144361443546
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.6,7.681657816578159
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.65,11.943614436144355
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.7,16.237257372573712
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.75,21.690156901568997
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.8,28.870125701257024
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.85,42.80470254702554
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.9,72.56742867428696
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.95,93.81359163591628
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.975,107.71987144871417
+2025-11-22,3,wk inc rsv hosp,2025-12-13,19,quantile,0.99,129.97066960669588
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.4,0.25763657636577286
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.45,2.099546995469961
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.5,4
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.55,6.28329883298834
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.6,8.774517745177455
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.65,11.774517745177455
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.7,14.916365163651633
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.75,19.127651276512772
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.8,23.93864938649387
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.85,29.709483094830922
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.9,36.68787687876878
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.95,46.39474694746946
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.975,55.647260222602085
+2025-11-22,3,wk inc rsv hosp,2025-12-13,20,quantile,0.99,67.36840758407583
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.35,2.970104701047017
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.4,6.668055680556814
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.45,9.970104701047017
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.5,13
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.55,16.47487174871746
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.6,20.28022980229803
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.65,24.874130741307425
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.7,30.13804938049385
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.75,36.192084420844225
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.8,43.602283022830264
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.85,53.25061500615003
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.9,69.16052560525598
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.95,110.63780337803398
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.975,139.68406984069824
+2025-11-22,3,wk inc rsv hosp,2025-12-13,21,quantile,0.99,161.02661896618943
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.25,5.006570065700667
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.3,10.29326193261932
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.35,14.629661296612959
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.4,18.224177241772423
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.45,21.2181036810368
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.5,24
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.55,26.80299852998529
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.6,30.062403624036243
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.65,33.7032385323853
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.7,38.504011040110385
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.75,44.681096810968114
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.8,52.76969069690694
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.85,63.28945939459393
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.9,78.36916869168698
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.95,99.84370143701436
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.975,112.76430564305637
+2025-11-22,3,wk inc rsv hosp,2025-12-13,22,quantile,0.99,134.621448114481
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.5,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.55,0.5805403054030553
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.6,1.0576245762457677
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.65,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.7,3
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.75,4.137588875888761
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.8,5.431542315423167
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.85,6.889484894848948
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.9,8.292691926919277
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.95,11
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.975,13.429944799447988
+2025-11-22,3,wk inc rsv hosp,2025-12-13,23,quantile,0.99,16.006570065700643
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.2,1.6567965679656795
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.25,7.682911829118287
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.3,12.361326613266126
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.35,16.369944199442
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.4,19.742447424474243
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.45,22.86707467074671
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.5,26
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.55,29.184036840368403
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.6,32.59318393183932
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.65,36.11080910809108
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.7,40.390756907569056
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.75,45.74244742447424
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.8,52.81761617616179
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.85,63.16073560735609
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.9,78.21469414694137
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.95,100.95562955629546
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.975,120.52313698137006
+2025-11-22,3,wk inc rsv hosp,2025-12-13,24,quantile,0.99,141.3079266792666
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.35,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.4,7.084018840188417
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.45,12.013896138961398
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.5,17
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.55,22
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.6,27.511253112531122
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.65,33.59416644166443
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.7,41
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.75,50.26550265502654
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.8,62.77251972519735
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.85,80.16266012660118
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.9,104.42971529715318
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.95,155.42496324963213
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.975,211.67293672936685
+2025-11-22,3,wk inc rsv hosp,2025-12-13,25,quantile,0.99,262.04318333183284
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.45,1.1587300873008632
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.5,8
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.55,16.839223892238913
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.6,25.63141031410308
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.65,37.17055770557702
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.7,47.85742657426569
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.75,61.81848318483187
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.8,77.41234812348128
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.85,93.78556235562351
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.9,118.54717547175477
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.95,162.5174526745266
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.975,202.89915624156234
+2025-11-22,3,wk inc rsv hosp,2025-12-13,26,quantile,0.99,252.14963339633385
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.3,2.126592265922655
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.35,6.834551345513457
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.4,11.315771157711584
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.45,15.152250022500217
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.5,18
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.55,21.27303723037234
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.6,25.248492484924817
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.65,29.82179071790717
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.7,34.795145951459524
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.75,39.88196381963819
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.8,44.744601446014485
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.85,51.23228482284822
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.9,60.87480274802751
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.95,74.31363663636631
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.975,87.366181411814
+2025-11-22,3,wk inc rsv hosp,2025-12-13,27,quantile,0.99,103.97874748747451
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.4,1.4065520655206611
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.45,3
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.5,5
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.55,6.780873308733093
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.6,8.713119131191323
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.65,11
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.7,13.614133141331394
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.75,16.6439489394894
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.8,20
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.85,23.817352173521698
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.9,28.825368253682495
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.95,36.62246872468723
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.975,43.4516012660126
+2025-11-22,3,wk inc rsv hosp,2025-12-13,28,quantile,0.99,52.22821798217982
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.45,1.4229742297422927
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.5,5
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.55,9.203033030330342
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.6,14.08053280532803
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.65,19.469840698406987
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.7,25
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.75,31.14977649776498
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.8,38.58636786367866
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.85,48.36133861338611
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.9,61.93662436624372
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.95,82.09339543395441
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.975,98.6267062670626
+2025-11-22,3,wk inc rsv hosp,2025-12-13,29,quantile,0.99,119.02324663246624
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.5,3.000030000466225e-5
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.55,1.125341253412535
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.6,2.8499924999249924
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.65,4.5355428554285515
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.7,6.685473854738522
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.75,8.895186451864525
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.8,11.033024330243304
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.85,14.241460414604155
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.9,19.386067860678644
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.95,28.645532955329514
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.975,33.99678996789968
+2025-11-22,3,wk inc rsv hosp,2025-12-13,30,quantile,0.99,41.99678996789968
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.35,1.5113851138511407
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.4,3.337413374133741
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.45,4.511385113851141
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.5,6
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.55,7.511385113851141
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.6,8.934917349173503
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.65,10.752131521315217
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.7,13.031485314853153
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.75,15.51138511385114
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.8,18.793747937479402
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.85,23.51138511385114
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.9,28.913614136141344
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.95,36.29381093810933
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.975,42.44956199561994
+2025-11-22,3,wk inc rsv hosp,2025-12-13,31,quantile,0.99,51.59929049290491
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.45,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.5,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.55,3
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.6,5
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.65,7.551435514355155
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.7,10.320919209192061
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.75,13.979284792847924
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.8,17.735349353493557
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.85,22.698219482194823
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.9,27.699342993429923
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.95,38.24712897128964
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.975,46.965317403174026
+2025-11-22,3,wk inc rsv hosp,2025-12-13,32,quantile,0.99,56.64420514205139
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.35,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.4,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.45,2.577654276542768
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.5,3
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.55,4
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.6,5
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.65,6
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.7,7.934038340383395
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.75,10.158394083940838
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.8,12.711511115111152
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.85,14.873977739777398
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.9,17
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.95,21.000718507185038
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.975,25.970391953919528
+2025-11-22,3,wk inc rsv hosp,2025-12-13,33,quantile,0.99,30.463455134551328
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.25,6.096105961059607
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.3,16.795181951819508
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.35,25.884554345543457
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.4,33.11741217412174
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.45,39.09610596105961
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.5,45
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.55,50.82736327363274
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.6,57.298385983859816
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.65,65.0961059610596
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.7,75.0961059610596
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.75,87.47746227462275
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.8,101.46696966969672
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.85,119.67307173071723
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.9,143.80218402184022
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.95,170.90411154111533
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.975,199.41824843248426
+2025-11-22,3,wk inc rsv hosp,2025-12-13,34,quantile,0.99,236.75712057120566
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.45,0.8982164821648209
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.5,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.55,3
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.6,4.928161281612817
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.65,7
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.7,10.794305943059435
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.75,15.997562475624747
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.8,22.487198871988774
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.85,28.03885788857888
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.9,33.6088800888009
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.95,49.334927849278444
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.975,63.23791287912871
+2025-11-22,3,wk inc rsv hosp,2025-12-13,35,quantile,0.99,76.42748987489861
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.25,5.058883088830903
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.3,26.47965979659797
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.35,46.380148801488005
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.4,62.65346053460536
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.45,76.0237437374374
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.5,88
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.55,100.09027390273906
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.6,114.42507425074251
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.65,132.03381933819344
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.7,153.12552725527252
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.75,176.070193201932
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.8,202.50105301053014
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.85,233.56474064740632
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.9,268.8296282962829
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.95,333.89768547685475
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.975,390.07275972759714
+2025-11-22,3,wk inc rsv hosp,2025-12-13,36,quantile,0.99,455.44264992649886
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.35,4.48706537065357
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.4,12.224810248102367
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.45,19.55931209312081
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.5,26
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.55,33.249624996249864
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.6,41.40973209732083
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.65,50.757170071700614
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.7,61.91848318483174
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.75,76.3126856268562
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.8,95.32707527075263
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.85,118.28663186631852
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.9,150.60983709837112
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.95,202.9359748597483
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.975,238.57152746527458
+2025-11-22,3,wk inc rsv hosp,2025-12-13,37,quantile,0.99,289.58677076770755
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.5,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.55,0.4049755497555023
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.6,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.65,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.7,3
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.75,4.06447064470645
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.8,5.989241892418932
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.85,8.338437884378875
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.9,11.802634026340264
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.95,16.874687246872533
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.975,20
+2025-11-22,3,wk inc rsv hosp,2025-12-13,38,quantile,0.99,24.419841898418976
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.3,2.591341913419134
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.35,11.546491464914588
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.4,19.041160411604125
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.45,25.3229067290673
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.5,31
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.55,36.90849308493087
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.6,44.03121231212313
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.65,53.195208952089544
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.7,65.16464764647645
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.75,79.70023700237003
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.8,96.60189601896016
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.85,118.82166171661714
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.9,155.29865298652965
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.95,210.141859418594
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.975,239.96027960279574
+2025-11-22,3,wk inc rsv hosp,2025-12-13,39,quantile,0.99,289.9472897728972
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.5,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.55,2.517257672576788
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.6,5.574991749917482
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.65,8.856030060300604
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.7,12.26172261722617
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.75,15.935994359943605
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.8,20.596075960759606
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.85,26.794211442114378
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.9,33.71863918639187
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.95,44.89935799357991
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.975,54.67895928959287
+2025-11-22,3,wk inc rsv hosp,2025-12-13,40,quantile,0.99,67.18680616806168
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.45,1.0200042000420027
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.5,3
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.55,5.532850328503287
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.6,8.577550775507772
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.65,13.162700627006291
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.7,17.965115651156495
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.75,23.75527255272558
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.8,31.99432694326945
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.85,41.25163351633517
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.9,50.53285032850329
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.95,63.63016680166798
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.975,77.6069330693304
+2025-11-22,3,wk inc rsv hosp,2025-12-13,41,quantile,0.99,96.45476014760142
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.25,11.392756427564318
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.3,31.166189661896667
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.35,50.289736897368996
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.4,68.6848918489186
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.45,84.29519095190956
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.5,99
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.55,113.81767017670182
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.6,130.61190111901124
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.65,149.7203972039721
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.7,169.80844808448083
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.75,191.35209102091025
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.8,217.69080190801952
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.85,254.7353583535835
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.9,308.6635406354063
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.95,407.71733117331144
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.975,492.8036262862639
+2025-11-22,3,wk inc rsv hosp,2025-12-13,42,quantile,0.99,582.3564737647383
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.4,0.09015090150901273
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.45,1.0767407674076708
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.5,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.55,2.9520940209402076
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.6,4.085596855968564
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.65,5.090150901509013
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.7,6.368856688566863
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.75,8.15482404824048
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.8,10.822248222482232
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.85,13.827640776407756
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.9,17.981963819638207
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.95,26.72675576755765
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.975,32.856134311343084
+2025-11-22,3,wk inc rsv hosp,2025-12-13,44,quantile,0.99,39.052367923679206
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.15,9.58246482464825
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.2,19
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.25,27.53359283592836
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.3,34.783778837788375
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.35,40.566455164551634
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.4,45.17851378513785
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.45,49.249185491854924
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.5,53
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.55,56.82263072630727
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.6,61
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.65,65.80904359043592
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.7,71.87120871208705
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.75,79.17937929379295
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.8,87.77993579935816
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.85,97.81770767707631
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.9,112.65862058620588
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.95,143.74226142261412
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.975,172.2221424714247
+2025-11-22,3,wk inc rsv hosp,2025-12-13,45,quantile,0.99,201.61282902829015
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.5,1.0500105000987858e-4
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.55,1.1095145951459529
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.6,1.4099360993609955
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.65,2.9077580775807803
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.7,3.99071190711906
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.75,5.309528095280949
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.8,7.414118141181403
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.85,10.175111751117512
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.9,13.175111751117512
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.95,16.744341943419442
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.975,20.12877478774787
+2025-11-22,3,wk inc rsv hosp,2025-12-13,46,quantile,0.99,25.492766327663226
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.3,0.34781147811477886
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.35,4.84165091650916
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.4,8.816350163501635
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.45,12.020190201902016
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.5,15
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.55,17.92914379143791
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.6,21.445534455344543
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.65,26.1138481384814
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.7,31.32259922599227
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.75,38.02019020190202
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.8,47.462436624366255
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.85,58.718951189511884
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.9,76.22896528965272
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.95,112.43593435934372
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.975,143.91450139501367
+2025-11-22,3,wk inc rsv hosp,2025-12-13,47,quantile,0.99,171.91040980409815
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.15,25.336232862328615
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.2,54.25119251192511
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.25,76.82097320973209
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.3,96.09041790417902
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.35,113.7431419314193
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.4,128.78010380103797
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.45,141.65901209012088
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.5,153
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.55,164.61538265382654
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.6,177.46070860708602
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.65,192.6227117271173
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.7,209.81313413134126
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.75,229.0550655506555
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.8,252.1569735697357
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.85,281.43913689136895
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.9,314.92302523025234
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.95,381.8781882818826
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.975,465.57817703177193
+2025-11-22,3,wk inc rsv hosp,2025-12-13,48,quantile,0.99,585.9615666156654
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.5,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.55,2.2796342963429668
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.6,4.803162031620268
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.65,8.303558035580323
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.7,12.631794317943163
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.75,19.49252992529925
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.8,27.490156901568984
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.85,39.19181441814416
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.9,48.62492724927253
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.95,58.65045600456003
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.975,72.33047205472062
+2025-11-22,3,wk inc rsv hosp,2025-12-13,49,quantile,0.99,94.56550835508338
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.5,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.55,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.6,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.65,2
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.7,2.5456154561545645
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.75,3.2400324003240115
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.8,4.58272582725829
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.85,6
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.9,8
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.95,10.587551375513723
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.975,13
+2025-11-22,3,wk inc rsv hosp,2025-12-13,50,quantile,0.99,15.923083130831309
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.25,3.0884183841838455
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.3,8.868484684846843
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.35,13.629029790297896
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.4,17.7318063180632
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.45,21.57559925599257
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.5,25
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.55,28.602181021810225
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.6,32.4939999399994
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.65,36.91852818528186
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.7,42.40283502835028
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.75,49.25306753067531
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.8,58.64361143611441
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.85,70.77944979449785
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.9,94.38306783067837
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.95,141.36833918339167
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.975,163.56787867878674
+2025-11-22,3,wk inc rsv hosp,2025-12-13,51,quantile,0.99,187.54203222032174
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.4,2.0098340983409733
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.45,4.766927669276697
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.5,7.000000000000001
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.55,9.766927669276697
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.6,13.105373053730537
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.65,16.828600786007865
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.7,20.93921039210396
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.75,25.467644676446767
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.8,30.267452674526822
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.85,35.84970149701486
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.9,44.80012000120002
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.95,60.06267212672149
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.975,74.16732367323677
+2025-11-22,3,wk inc rsv hosp,2025-12-13,53,quantile,0.99,89.82683946839444
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.5,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.55,2.239948399483999
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.6,5
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.65,7.802622026220266
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.7,11
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.75,15
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.8,19.5708637086371
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.85,25.09265892658923
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.9,33.81294212942129
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.95,45.62185071850719
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.975,55.02289847898478
+2025-11-22,3,wk inc rsv hosp,2025-12-13,54,quantile,0.99,67.9672672726726
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.45,2.0988809888098907
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.5,5
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.55,8
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.6,11.154381543815436
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.65,15.086583865838644
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.7,20.01618816188162
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.75,25.545892958929564
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.8,31.468514685146857
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.85,37.759282092820925
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.9,45.54973149731499
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.95,59.64913899138997
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.975,72.18731212312115
+2025-11-22,3,wk inc rsv hosp,2025-12-13,55,quantile,0.99,86.56990609906097
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.2,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.25,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.3,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.35,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.4,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.45,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.5,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.55,1
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.6,2.134407344073438
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.65,3.938100381003812
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.7,5.881612816128163
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.75,7.494097440974407
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.8,9.302667026670278
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.85,11.443023430234303
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.9,15.08611586115862
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.95,19.909162091620914
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.975,24.240592655926594
+2025-11-22,3,wk inc rsv hosp,2025-12-13,56,quantile,0.99,29.675322653226566
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.1,42.93077130771308
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.15,66.24257642576426
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.2,82.54454744547448
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.25,95.63937389373895
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.3,106.1607446074461
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.35,115.40820058200578
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.4,122.92328923289233
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.45,129.13642486424862
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.5,135
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.55,140.44855398553983
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.6,146.86575465754657
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.65,154.38032580325805
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.7,163.40125701257003
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.75,174.27752527525277
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.8,188
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.85,204.2655791557915
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.9,228.6943599435992
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.95,282.835695856958
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.975,336.8604678546786
+2025-11-22,3,wk inc rsv hosp,2025-12-13,72,quantile,0.99,384.73717337173355
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.01,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.025,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.05,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.1,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.15,0
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.2,145.62810428104314
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.25,416.6935919359194
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.3,661.6163681636808
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.35,887.6616101161012
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.4,1094.3181051810525
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.45,1275.958178081781
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.5,1432
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.55,1594.5579845798457
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.6,1779.2891548915482
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.65,1991.385730357304
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.7,2220.633630336303
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.75,2478.629488794888
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.8,2763.1025710257104
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.85,3134.227423274231
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.9,3621.550220502206
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.95,4456.349026490265
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.975,5150.0151756517525
+2025-11-22,3,wk inc rsv hosp,2025-12-13,US,quantile,0.99,6009.406605466051
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.01,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.025,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.05,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.1,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.15,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.2,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.25,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.3,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.35,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.4,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.45,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.5,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.55,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.6,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.65,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.7,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.75,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.8,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.85,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.9,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.95,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.975,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,01,quantile,0.99,0.0033
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.01,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.025,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.05,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.1,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.15,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.2,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.25,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.3,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.35,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.4,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.45,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.5,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.55,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.6,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.65,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.7,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.75,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.8,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.85,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.9,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.95,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.975,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,02,quantile,0.99,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.01,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.025,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.05,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.1,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.15,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.2,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.25,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.3,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.35,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.4,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.45,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.5,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.55,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.6,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.65,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.7,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.75,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.8,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.85,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.9,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.95,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.975,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,04,quantile,0.99,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.01,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.025,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.05,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.1,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.15,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.2,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.25,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.3,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.35,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.4,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.45,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.5,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.55,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.6,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.65,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.7,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.75,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.8,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.85,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.9,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.95,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.975,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,05,quantile,0.99,0.0068000000000000005
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.01,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.025,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.05,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.1,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.15,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.2,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.25,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.3,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.35,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.4,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.45,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.5,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.55,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.6,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.65,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.7,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.75,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.8,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.85,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.9,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.95,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.975,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,06,quantile,0.99,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.01,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.025,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.05,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.1,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.15,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.2,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.25,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.3,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.35,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.4,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.45,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.5,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.55,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.6,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.65,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.7,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.75,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.8,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.85,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.9,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.95,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.975,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,08,quantile,0.99,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.01,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.025,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.05,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.1,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.15,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.2,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.25,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.3,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.35,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.4,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.45,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.5,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.55,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.6,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.65,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.7,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.75,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.8,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.85,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.9,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.95,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.975,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,09,quantile,0.99,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.01,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.025,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.05,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.1,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.15,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.2,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.25,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.3,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.35,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.4,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.45,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.5,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.55,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.6,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.65,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.7,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.75,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.8,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.85,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.9,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.95,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.975,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,10,quantile,0.99,0.0017000000000000001
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.01,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.025,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.05,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.1,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.15,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.2,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.25,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.3,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.35,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.4,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.45,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.5,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.55,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.6,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.65,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.7,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.75,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.8,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.85,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.9,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.95,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.975,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,11,quantile,0.99,0.0016
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.01,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.025,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.05,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.1,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.15,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.2,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.25,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.3,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.35,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.4,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.45,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.5,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.55,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.6,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.65,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.7,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.75,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.8,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.85,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.9,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.95,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.975,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,12,quantile,0.99,0.0049
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.01,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.025,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.05,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.1,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.15,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.2,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.25,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.3,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.35,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.4,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.45,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.5,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.55,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.6,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.65,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.7,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.75,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.8,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.85,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.9,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.95,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.975,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,13,quantile,0.99,0.0021
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.01,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.025,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.05,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.1,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.15,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.2,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.25,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.3,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.35,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.4,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.45,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.5,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.55,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.6,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.65,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.7,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.75,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.8,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.85,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.9,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.95,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.975,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,15,quantile,0.99,0.0018
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.01,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.025,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.05,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.1,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.15,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.2,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.25,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.3,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.35,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.4,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.45,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.5,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.55,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.6,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.65,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.7,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.75,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.8,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.85,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.9,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.95,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.975,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,16,quantile,0.99,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.01,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.025,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.05,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.1,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.15,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.2,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.25,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.3,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.35,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.4,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.45,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.5,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.55,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.6,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.65,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.7,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.75,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.8,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.85,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.9,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.95,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.975,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,17,quantile,0.99,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.01,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.025,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.05,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.1,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.15,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.2,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.25,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.3,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.35,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.4,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.45,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.5,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.55,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.6,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.65,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.7,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.75,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.8,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.85,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.9,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.95,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.975,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,18,quantile,0.99,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.01,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.025,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.05,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.1,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.15,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.2,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.25,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.3,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.35,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.4,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.45,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.5,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.55,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.6,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.65,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.7,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.75,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.8,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.85,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.9,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.95,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.975,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,19,quantile,0.99,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.01,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.025,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.05,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.1,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.15,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.2,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.25,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.3,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.35,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.4,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.45,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.5,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.55,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.6,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.65,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.7,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.75,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.8,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.85,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.9,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.95,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.975,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,20,quantile,0.99,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.01,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.025,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.05,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.1,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.15,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.2,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.25,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.3,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.35,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.4,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.45,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.5,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.55,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.6,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.65,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.7,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.75,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.8,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.85,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.9,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.95,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.975,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,21,quantile,0.99,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.01,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.025,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.05,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.1,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.15,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.2,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.25,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.3,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.35,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.4,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.45,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.5,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.55,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.6,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.65,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.7,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.75,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.8,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.85,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.9,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.95,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.975,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,22,quantile,0.99,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.01,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.025,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.05,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.1,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.15,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.2,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.25,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.3,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.35,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.4,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.45,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.5,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.55,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.6,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.65,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.7,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.75,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.8,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.85,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.9,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.95,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.975,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,23,quantile,0.99,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.01,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.025,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.05,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.1,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.15,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.2,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.25,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.3,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.35,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.4,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.45,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.5,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.55,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.6,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.65,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.7,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.75,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.8,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.85,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.9,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.95,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.975,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,24,quantile,0.99,0.0014000000000000002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.01,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.025,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.05,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.1,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.15,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.2,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.25,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.3,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.35,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.4,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.45,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.5,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.55,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.6,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.65,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.7,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.75,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.8,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.85,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.9,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.95,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.975,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,25,quantile,0.99,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.01,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.025,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.05,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.1,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.15,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.2,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.25,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.3,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.35,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.4,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.45,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.5,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.55,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.6,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.65,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.7,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.75,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.8,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.85,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.9,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.95,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.975,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,26,quantile,0.99,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.01,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.025,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.05,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.1,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.15,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.2,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.25,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.3,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.35,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.4,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.45,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.5,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.55,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.6,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.65,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.7,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.75,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.8,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.85,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.9,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.95,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.975,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,27,quantile,0.99,8e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.01,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.025,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.05,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.1,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.15,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.2,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.25,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.3,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.35,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.4,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.45,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.5,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.55,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.6,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.65,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.7,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.75,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.8,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.85,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.9,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.95,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.975,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,28,quantile,0.99,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.01,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.025,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.05,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.1,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.15,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.2,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.25,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.3,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.35,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.4,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.45,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.5,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.55,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.6,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.65,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.7,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.75,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.8,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.85,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.9,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.95,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.975,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,30,quantile,0.99,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.01,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.025,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.05,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.1,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.15,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.2,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.25,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.3,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.35,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.4,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.45,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.5,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.55,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.6,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.65,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.7,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.75,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.8,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.85,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.9,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.95,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.975,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,31,quantile,0.99,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.01,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.025,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.05,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.1,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.15,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.2,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.25,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.3,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.35,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.4,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.45,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.5,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.55,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.6,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.65,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.7,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.75,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.8,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.85,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.9,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.95,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.975,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,32,quantile,0.99,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.01,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.025,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.05,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.1,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.15,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.2,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.25,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.3,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.35,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.4,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.45,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.5,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.55,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.6,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.65,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.7,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.75,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.8,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.85,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.9,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.95,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.975,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,33,quantile,0.99,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.01,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.025,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.05,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.1,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.15,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.2,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.25,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.3,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.35,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.4,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.45,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.5,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.55,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.6,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.65,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.7,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.75,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.8,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.85,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.9,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.95,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.975,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,34,quantile,0.99,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.01,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.025,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.05,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.1,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.15,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.2,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.25,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.3,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.35,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.4,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.45,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.5,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.55,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.6,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.65,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.7,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.75,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.8,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.85,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.9,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.95,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.975,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,35,quantile,0.99,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.01,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.025,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.05,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.1,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.15,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.2,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.25,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.3,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.35,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.4,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.45,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.5,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.55,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.6,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.65,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.7,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.75,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.8,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.85,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.9,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.95,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.975,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,36,quantile,0.99,7.000000000000001e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.01,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.025,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.05,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.1,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.15,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.2,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.25,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.3,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.35,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.4,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.45,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.5,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.55,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.6,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.65,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.7,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.75,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.8,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.85,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.9,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.95,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.975,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,37,quantile,0.99,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.01,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.025,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.05,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.1,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.15,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.2,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.25,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.3,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.35,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.4,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.45,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.5,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.55,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.6,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.65,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.7,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.75,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.8,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.85,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.9,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.95,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.975,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,38,quantile,0.99,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.01,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.025,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.05,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.1,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.15,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.2,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.25,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.3,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.35,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.4,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.45,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.5,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.55,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.6,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.65,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.7,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.75,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.8,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.85,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.9,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.95,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.975,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,39,quantile,0.99,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.01,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.025,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.05,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.1,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.15,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.2,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.25,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.3,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.35,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.4,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.45,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.5,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.55,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.6,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.65,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.7,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.75,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.8,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.85,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.9,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.95,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.975,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,40,quantile,0.99,3e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.01,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.025,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.05,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.1,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.15,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.2,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.25,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.3,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.35,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.4,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.45,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.5,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.55,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.6,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.65,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.7,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.75,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.8,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.85,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.9,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.95,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.975,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,41,quantile,0.99,4e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.01,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.025,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.05,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.1,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.15,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.2,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.25,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.3,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.35,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.4,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.45,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.5,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.55,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.6,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.65,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.7,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.75,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.8,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.85,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.9,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.95,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.975,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,42,quantile,0.99,6e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.01,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.025,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.05,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.1,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.15,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.2,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.25,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.3,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.35,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.4,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.45,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.5,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.55,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.6,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.65,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.7,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.75,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.8,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.85,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.9,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.95,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.975,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,44,quantile,0.99,0.0013
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.01,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.025,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.05,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.1,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.15,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.2,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.25,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.3,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.35,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.4,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.45,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.5,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.55,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.6,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.65,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.7,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.75,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.8,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.85,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.9,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.95,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.975,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,45,quantile,0.99,0.003
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.01,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.025,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.05,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.1,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.15,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.2,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.25,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.3,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.35,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.4,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.45,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.5,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.55,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.6,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.65,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.7,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.75,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.8,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.85,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.9,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.95,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.975,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,46,quantile,0.99,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.01,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.025,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.05,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.1,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.15,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.2,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.25,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.3,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.35,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.4,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.45,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.5,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.55,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.6,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.65,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.7,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.75,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.8,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.85,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.9,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.95,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.975,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,47,quantile,0.99,9e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.01,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.025,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.05,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.1,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.15,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.2,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.25,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.3,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.35,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.4,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.45,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.5,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.55,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.6,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.65,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.7,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.75,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.8,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.85,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.9,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.95,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.975,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,48,quantile,0.99,0.0027
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.01,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.025,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.05,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.1,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.15,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.2,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.25,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.3,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.35,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.4,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.45,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.5,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.55,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.6,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.65,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.7,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.75,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.8,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.85,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.9,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.95,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.975,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,49,quantile,0.99,1e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.01,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.025,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.05,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.1,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.15,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.2,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.25,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.3,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.35,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.4,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.45,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.5,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.55,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.6,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.65,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.7,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.75,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.8,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.85,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.9,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.95,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.975,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,50,quantile,0.99,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.01,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.025,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.05,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.1,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.15,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.2,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.25,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.3,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.35,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.4,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.45,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.5,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.55,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.6,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.65,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.7,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.75,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.8,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.85,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.9,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.95,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.975,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,51,quantile,0.99,0.002
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.01,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.025,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.05,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.1,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.15,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.2,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.25,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.3,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.35,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.4,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.45,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.5,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.55,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.6,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.65,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.7,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.75,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.8,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.85,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.9,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.95,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.975,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,53,quantile,0.99,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.01,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.025,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.05,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.1,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.15,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.2,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.25,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.3,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.35,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.4,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.45,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.5,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.55,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.6,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.65,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.7,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.75,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.8,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.85,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.9,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.95,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.975,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,54,quantile,0.99,0.0011
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.01,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.025,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.05,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.1,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.15,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.2,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.25,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.3,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.35,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.4,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.45,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.5,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.55,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.6,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.65,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.7,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.75,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.8,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.85,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.9,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.95,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.975,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,55,quantile,0.99,2e-4
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.01,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.025,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.05,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.1,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.15,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.2,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.25,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.3,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.35,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.4,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.45,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.5,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.55,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.6,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.65,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.7,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.75,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.8,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.85,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.9,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.95,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.975,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,56,quantile,0.99,0
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.01,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.025,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.05,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.1,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.15,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.2,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.25,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.3,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.35,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.4,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.45,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.5,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.55,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.6,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.65,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.7,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.75,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.8,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.85,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.9,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.95,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.975,0.0015
+2025-11-22,-1,wk inc rsv prop ed visits,2025-11-15,US,quantile,0.99,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.01,3.749999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.025,0.001299999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.05,0.0018000000000000004
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.1,0.0024000000000000007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.15,0.0029
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.2,0.003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.25,0.0031
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.3,0.0031000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.35,0.0031999999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.4,0.0032
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.45,0.0033
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.5,0.0033
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.55,0.0033
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.6,0.0034
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.65,0.0034000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.7,0.0034999999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.75,0.0035
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.8,0.0036
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.85,0.0037
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.9,0.004199999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.95,0.0048
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.975,0.005300000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,01,quantile,0.99,0.006224999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.3,9.999999999999994e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.35,1.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.4,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.45,3.250000000000015e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.5,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.55,4.750000000000009e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.6,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.65,6.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.7,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.75,9.000000000000004e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.8,0.001199947999479996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.85,0.0017000000000000012
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.9,0.0026500000000000004
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.95,0.003974999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.975,0.004962499999999991
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,02,quantile,0.99,0.006049999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.25,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.3,1.0000000000000005e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.35,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.4,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.45,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.5,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.55,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.6,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.65,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.7,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.75,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.8,4.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.85,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.9,9.499999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.95,0.0014749999999999945
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.975,0.0018
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,04,quantile,0.99,0.0027999999999999926
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.01,0.001225
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.025,0.003137500000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.05,0.004300000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.1,0.005750000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.15,0.006200000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.2,0.006500000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.25,0.0066
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.3,0.006600000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.35,0.0067
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.4,0.0067
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.45,0.006725000000000005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.5,0.0068000000000000005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.55,0.006874999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.6,0.006900000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.65,0.006900000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.7,0.007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.75,0.007000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.8,0.0071
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.85,0.0074
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.9,0.007850000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.95,0.0093
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.975,0.010462499999999994
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,05,quantile,0.99,0.012374999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.15,2.7499999999999937e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.2,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.25,4.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.3,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.35,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.4,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.45,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.5,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.55,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.6,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.65,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.7,6.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.75,7e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.8,7.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.85,9.250000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.9,0.0012
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.95,0.0016000000000000007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.975,0.002199999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,06,quantile,0.99,0.002674999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.15,1.6263032587282567e-19
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.2,1.9999999999999993e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.25,2.0000000000000006e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.3,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.35,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.4,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.45,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.5,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.55,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.6,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.65,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.7,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.75,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.8,6.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.85,7.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.9,0.001050000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.95,0.0022749999999999953
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.975,0.0032499999999999907
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,08,quantile,0.99,0.005149999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.15,9.999999999999994e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.2,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.25,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.3,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.35,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.4,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.45,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.5,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.55,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.6,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.65,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.7,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.75,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.8,6.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.85,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.9,9.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.95,0.0014749999999999952
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.975,0.002000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,09,quantile,0.99,0.0026749999999999994
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.1,3.500000000000008e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.15,9.000000000000005e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.2,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.25,0.0014000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.3,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.35,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.4,0.0016
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.45,0.0016
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.5,0.0017000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.55,0.0018000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.6,0.0018000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.65,0.0019000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.7,0.0019000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.75,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.8,0.0022
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.85,0.0024999999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.9,0.00305
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.95,0.004949999999999971
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.975,0.00634999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,10,quantile,0.99,0.008299999999999991
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.1,5.000000000000002e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.15,9.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.2,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.25,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.3,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.35,0.0014000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.4,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.45,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.5,0.0016
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.55,0.0017000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.6,0.0017000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.65,0.0018
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.7,0.0019000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.75,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.8,0.0021000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.85,0.0023
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.9,0.0027
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.95,0.0037499999999999903
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.975,0.005149999999999988
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,11,quantile,0.99,0.005549999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.01,0.0036250000000000006
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.025,0.003999999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.05,0.0042
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.1,0.004399999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.15,0.0046
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.2,0.004699999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.25,0.0047
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.3,0.0048
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.35,0.0048
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.4,0.0049
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.45,0.0049
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.5,0.0049
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.55,0.0049
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.6,0.0049
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.65,0.005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.7,0.005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.75,0.0050999999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.8,0.0051
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.85,0.0052
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.9,0.0054
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.95,0.0056
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.975,0.0058000000000000005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,12,quantile,0.99,0.006174999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.01,5.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.025,7.999999999999993e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.05,0.0011999999999999992
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.1,0.0015999999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.15,0.0018
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.2,0.0019
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.25,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.3,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.35,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.4,0.0021
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.45,0.0021
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.5,0.0021
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.55,0.0021
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.6,0.0021
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.65,0.0021999999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.7,0.0021999999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.75,0.0021999999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.8,0.0023
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.85,0.0024
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.9,0.0026
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.95,0.0030000000000000005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.975,0.0034000000000000007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,13,quantile,0.99,0.0036
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.05,4.999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.1,9.999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.15,0.0010999999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.2,0.0013000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.25,0.0014999999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.3,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.35,0.0015999999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.4,0.0017
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.45,0.0017
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.5,0.0018
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.55,0.0019
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.6,0.0019
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.65,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.7,0.0021
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.75,0.0021000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.8,0.0023
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.85,0.0025
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.9,0.0026000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.95,0.0031000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.975,0.0037874999999999975
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,15,quantile,0.99,0.004999999999999991
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.3,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.35,9.999999999999994e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.4,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.45,1.0000000000000005e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.5,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.55,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.6,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.65,3.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.7,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.75,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.8,6.000000000000002e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.85,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.9,0.0016000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.95,0.002800000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.975,0.003987499999999979
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,16,quantile,0.99,0.0056499999999999944
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.15,1.9999999999999977e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.2,3.9999999999999986e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.25,4.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.3,4.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.35,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.4,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.45,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.5,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.55,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.6,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.65,6.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.7,7e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.75,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.8,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.85,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.9,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.95,0.002600000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.975,0.0035624999999999915
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,17,quantile,0.99,0.004149999999999987
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.15,1.9999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.2,3.0005200052000595e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.25,4.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.3,4.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.35,4.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.4,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.45,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.5,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.55,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.6,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.65,7e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.7,7e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.75,7.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.8,8.999479994799961e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.85,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.9,0.001399999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.95,0.0021000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.975,0.0026749999999999942
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,18,quantile,0.99,0.003599999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.25,5.421010862427522e-20
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.3,9.999999999999999e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.35,1.9999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.4,1.9999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.45,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.5,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.55,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.6,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.65,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.7,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.75,5.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.8,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.85,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.9,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.95,0.0026
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.975,0.0037374999999999887
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,19,quantile,0.99,0.004849999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.2,5.421010862427522e-20
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.25,9.999999999999996e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.3,1.9999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.35,1.9999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.4,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.45,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.5,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.55,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.6,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.65,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.7,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.75,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.8,5.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.85,7.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.9,0.0011499999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.95,0.001874999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.975,0.002962499999999993
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,20,quantile,0.99,0.0039249999999999945
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.1,2.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.15,8.000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.2,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.25,0.0010999999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.3,0.0011499999999999982
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.35,0.0012
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.4,0.0012
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.45,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.5,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.55,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.6,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.65,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.7,0.0014499999999999956
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.75,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.8,0.0015999999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.85,0.0017999999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.9,0.0023
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.95,0.0034000000000000007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.975,0.004174999999999994
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,21,quantile,0.99,0.005099999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.025,2.9999999999999905e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.05,0.0011999999999999992
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.1,0.0019000000000000006
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.15,0.0024
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.2,0.0024999999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.25,0.0025
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.3,0.0026
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.35,0.0026000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.4,0.0026999219992199937
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.45,0.0027
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.5,0.0027
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.55,0.0027
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.6,0.002700078000780006
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.65,0.0028
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.7,0.0028000000000000004
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.75,0.0029000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.8,0.0029000000000000007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.85,0.0030000000000000005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.9,0.0034999999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.95,0.004200000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.975,0.005100000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,22,quantile,0.99,0.005699999999999991
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.25,5.692061405548898e-19
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.3,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.35,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.4,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.45,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.5,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.55,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.6,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.65,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.7,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.75,3.999999999999994e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.8,4.0005200052000843e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.85,6.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.9,9.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.95,0.001874999999999994
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.975,0.0024749999999999954
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,23,quantile,0.99,0.0037499999999999964
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.1,3.500000000000008e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.15,8.000000000000004e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.2,0.0011000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.25,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.3,0.0013000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.35,0.0013000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.4,0.0013000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.45,0.0014000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.5,0.0014000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.55,0.0014000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.6,0.0015000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.65,0.0015000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.7,0.0015000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.75,0.0016000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.8,0.0017000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.85,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.9,0.0024500000000000004
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.95,0.0035499999999999902
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.975,0.004574999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,24,quantile,0.99,0.0048000000000000004
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.15,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.2,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.25,7e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.3,7.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.35,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.4,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.45,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.5,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.55,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.6,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.65,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.7,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.75,0.0010999999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.8,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.85,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.9,0.0020500000000000006
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.95,0.003274999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.975,0.004187499999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,25,quantile,0.99,0.004600000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.2,5.2000520005544316e-8
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.25,1.9999999999999993e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.3,1.9999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.35,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.4,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.45,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.5,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.55,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.6,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.65,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.7,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.75,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.8,5.999479994799965e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.85,7.999999999999997e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.9,0.0013000000000000004
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.95,0.0024249999999999845
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.975,0.0031874999999999968
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,26,quantile,0.99,0.0041749999999999895
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.15,9.999999999999994e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.2,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.25,6.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.3,7e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.35,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.4,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.45,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.5,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.55,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.6,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.65,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.7,9.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.75,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.8,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.85,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.9,0.0021000000000000007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.95,0.0027499999999999903
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.975,0.0038499999999999893
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,27,quantile,0.99,0.004799999999999993
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.1,2.500000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.15,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.2,6.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.25,7e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.3,7.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.35,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.4,8.000780007800089e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.45,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.5,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.55,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.6,9.999219992199927e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.65,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.7,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.75,0.0010999999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.8,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.85,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.9,0.0015500000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.95,0.0023
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.975,0.003100000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,28,quantile,0.99,0.0036749999999999977
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.3,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.35,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.4,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.45,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.5,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.55,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.6,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.65,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.7,1.499999999999959e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.75,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.8,3.0005200052000844e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.85,7.250000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.9,0.0011000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.95,0.0026999999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.975,0.003987499999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,30,quantile,0.99,0.0043749999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.3,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.35,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.4,9.992199921999373e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.45,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.5,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.55,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.6,1.000780007800063e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.65,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.7,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.75,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.8,3.000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.85,5.250000000000004e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.9,9.000000000000002e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.95,0.0017000000000000008
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.975,0.0021874999999999967
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,31,quantile,0.99,0.0029749999999999985
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.3,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.35,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.4,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.45,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.5,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.55,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.6,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.65,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.7,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.75,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.8,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.85,7.250000000000006e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.9,0.0010500000000000012
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.95,0.0020749999999999944
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.975,0.002774999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,32,quantile,0.99,0.0030749999999999983
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.25,1.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.3,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.35,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.4,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.45,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.5,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.55,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.6,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.65,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.7,6.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.75,6.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.8,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.85,0.001225
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.9,0.00165
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.95,0.002674999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.975,0.0040874999999999965
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,33,quantile,0.99,0.005100000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.1,4.500000000000008e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.15,7.000000000000006e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.2,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.25,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.3,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.35,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.4,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.45,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.5,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.55,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.6,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.65,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.7,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.75,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.8,0.0013000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.85,0.0014999999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.9,0.00175
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.95,0.0023
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.975,0.003074999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,34,quantile,0.99,0.003724999999999994
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.3,9.999999999999996e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.35,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.4,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.45,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.5,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.55,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.6,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.65,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.7,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.75,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.8,6.999479994799964e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.85,0.0010250000000000007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.9,0.0018500000000000007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.95,0.003574999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.975,0.0045874999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,35,quantile,0.99,0.007924999999999988
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.1,1.5000000000000047e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.15,4.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.2,5.000000000000002e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.25,6.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.3,6.000000000000002e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.35,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.4,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.45,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.5,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.55,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.6,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.65,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.7,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.75,8.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.8,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.85,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.9,0.0012500000000000005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.95,0.0017749999999999955
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.975,0.0024000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,36,quantile,0.99,0.003099999999999992
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.1,6.000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.15,0.0010000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.2,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.25,0.0013000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.3,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.35,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.4,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.45,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.5,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.55,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.6,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.65,0.0016
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.7,0.0016
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.75,0.0017
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.8,0.0018
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.85,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.9,0.0024
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.95,0.0033000000000000004
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.975,0.003987499999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,37,quantile,0.99,0.005424999999999988
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.3,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.35,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.4,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.45,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.5,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.55,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.6,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.65,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.7,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.75,4.7500000000000005e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.8,5.000520005200085e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.85,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.9,0.0013999999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.95,0.0022249999999999844
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.975,0.004062499999999993
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,38,quantile,0.99,0.0064
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.15,9.999999999999983e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.2,1.9999999999999993e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.25,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.3,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.35,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.4,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.45,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.5,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.55,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.6,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.65,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.7,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.75,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.8,6.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.85,7.000000000000002e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.9,9.000000000000004e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.95,0.0017999999999999802
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.975,0.002400000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,39,quantile,0.99,0.003049999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.3,1.0000000000000002e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.35,1.9999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.4,1.9999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.45,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.5,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.55,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.6,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.65,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.7,4.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.75,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.8,6.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.85,8.000000000000004e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.9,0.001250000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.95,0.0023499999999999897
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.975,0.00324999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,40,quantile,0.99,0.004299999999999992
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.2,1.9994799947999493e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.25,2.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.3,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.35,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.4,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.45,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.5,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.55,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.6,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.65,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.7,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.75,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.8,6.000520005200088e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.85,9.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.9,0.0014999999999999994
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.95,0.0021499999999999918
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.975,0.003187499999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,41,quantile,0.99,0.003474999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.15,2.0000000000000015e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.2,4.999479994799951e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.25,4.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.3,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.35,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.4,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.45,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.5,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.55,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.6,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.65,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.7,6.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.75,7e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.8,7.000520005200086e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.85,9.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.9,0.0013499999999999994
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.95,0.0021749999999999946
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.975,0.003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,42,quantile,0.99,0.0034000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.1,4.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.15,8.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.2,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.25,0.0010999999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.3,0.0011999999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.35,0.0012
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.4,0.0012
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.45,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.5,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.55,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.6,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.65,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.7,0.0014000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.75,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.8,0.0015999999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.85,0.0017000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.9,0.0021000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.95,0.0031749999999999947
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.975,0.0041
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,44,quantile,0.99,0.0046749999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.01,6.250000000000002e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.025,0.0010249999999999988
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.05,0.0017000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.1,0.00225
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.15,0.0026
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.2,0.0027
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.25,0.0028
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.3,0.0029
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.35,0.0029000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.4,0.0029000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.45,0.003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.5,0.003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.55,0.003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.6,0.0031
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.65,0.0031
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.7,0.0031000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.75,0.0032
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.8,0.0033
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.85,0.0034000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.9,0.0037500000000000007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.95,0.0043
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.975,0.004974999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,45,quantile,0.99,0.005374999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.3,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.35,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.4,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.45,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.5,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.55,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.6,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.65,9.999999999999999e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.7,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.75,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.8,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.85,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.9,0.0014500000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.95,0.002274999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.975,0.003187499999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,46,quantile,0.99,0.004024999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.1,4.999999999999978e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.15,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.2,6.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.25,7e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.3,7.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.35,7.999999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.4,8e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.45,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.5,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.55,9e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.6,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.65,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.7,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.75,0.0010999999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.8,0.0012
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.85,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.9,0.001750000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.95,0.0025000000000000005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.975,0.0029
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,47,quantile,0.99,0.0037999999999999913
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.025,5.99999999999999e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.05,0.0011250000000000008
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.1,0.00175
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.15,0.0022
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.2,0.0024000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.25,0.0025000000000000005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.3,0.0026
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.35,0.0026000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.4,0.0026000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.45,0.0027
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.5,0.0027
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.55,0.0027
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.6,0.0028
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.65,0.0028
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.7,0.0028000000000000004
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.75,0.0029
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.8,0.003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.85,0.0032
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.9,0.0036500000000000013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.95,0.004274999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.975,0.004800000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,48,quantile,0.99,0.005549999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.3,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.35,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.4,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.45,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.5,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.55,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.6,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.65,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.7,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.75,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.8,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.85,7.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.9,0.0014500000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.95,0.0026000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.975,0.0038749999999999965
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,49,quantile,0.99,0.005900000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.3,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.35,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.4,1.0000000000000005e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.45,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.5,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.55,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.6,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.65,4e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.7,5e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.75,6e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.8,7e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.85,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.9,0.0014500000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.95,0.0031749999999999947
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.975,0.0045499999999999916
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,50,quantile,0.99,0.00577499999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.025,4.999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.05,8.250000000000002e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.1,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.15,0.0016
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.2,0.0018
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.25,0.0018999999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.3,0.0019
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.35,0.0019
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.4,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.45,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.5,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.55,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.6,0.002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.65,0.0021
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.7,0.0021
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.75,0.0021000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.8,0.0022
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.85,0.0024000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.9,0.0027
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.95,0.003174999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.975,0.0035000000000000005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,51,quantile,0.99,0.00417499999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.15,5.999999999999988e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.2,8.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.25,9.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.3,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.35,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.4,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.45,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.5,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.55,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.6,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.65,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.7,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.75,0.0012000000000000003
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.8,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.85,0.0016000000000000014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.9,0.0022000000000000014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.95,0.002949999999999991
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.975,0.004
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,53,quantile,0.99,0.005624999999999992
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.15,6.505213034913027e-19
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.2,6.000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.25,8.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.3,9.000000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.35,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.4,0.001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.45,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.5,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.55,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.6,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.65,0.0012000000000000001
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.7,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.75,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.8,0.0015999999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.85,0.0021999999999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.9,0.00325
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.95,0.00444999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.975,0.006474999999999974
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,54,quantile,0.99,0.007974999999999998
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.25,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.3,1e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.35,1.0000000000000005e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.4,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.45,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.5,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.55,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.6,2e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.65,3e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.7,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.75,3.0000000000000003e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.8,4.999479994799965e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.85,7.999999999999998e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.9,0.0010000000000000005
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.95,0.0019749999999999946
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.975,0.002687499999999997
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,55,quantile,0.99,0.002974999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.05,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.1,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.15,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.2,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.25,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.3,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.35,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.4,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.45,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.5,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.55,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.6,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.65,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.7,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.75,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.8,9.99479994799964e-5
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.85,5.25000000000001e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.9,0.0013
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.95,0.003224999999999986
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.975,0.004900000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,56,quantile,0.99,0.007049999999999995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.01,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.025,0
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.05,3.9999999999999996e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.1,8.500000000000009e-4
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.15,0.0011
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.2,0.001299947999479995
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.25,0.0013250000000000007
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.3,0.0014
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.35,0.0014000000000000002
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.4,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.45,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.5,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.55,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.6,0.0015
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.65,0.0015999999999999999
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.7,0.0016
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.75,0.0016749999999999994
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.8,0.001700052000520009
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.85,0.0019
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.9,0.0021499999999999996
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.95,0.0026
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.975,0.0030874999999999982
+2025-11-22,0,wk inc rsv prop ed visits,2025-11-22,US,quantile,0.99,0.0032
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.025,4.467299672996724e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.05,0.0011593254432544335
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.1,0.001804610946109462
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.15,0.0023
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.2,0.0026551349513495143
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.25,0.0029
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.3,0.003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.35,0.0031
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.4,0.0031999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.45,0.0032
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.5,0.0033
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.55,0.0034
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.6,0.0034000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.65,0.0035
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.7,0.0036
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.75,0.0037
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.8,0.0039493132931329306
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.85,0.0043
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.9,0.004799999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.95,0.005444854148541482
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.975,0.006143516110161099
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,01,quantile,0.99,0.0068185526755267555
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.35,5.421010862427522e-20
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.4,1.9999999999999928e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.45,3e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.5,4e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.55,5.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.6,7.010404104041032e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.65,9.470817208172076e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.7,0.0012458285582855806
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.75,0.0017
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.8,0.0022999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.85,0.0030000000000000014
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.9,0.0038911181111811093
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.95,0.005
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.975,0.0060793447934479345
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,02,quantile,0.99,0.007131407584075839
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.3,9.999999999999904e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.35,1e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.4,1.0000000000000026e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.45,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.5,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.55,2.4045500455004422e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.6,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.65,3.5207977079770934e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.7,4.000000000000005e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.75,5.505810058100583e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.8,7.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.85,0.0010999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.9,0.0014049319493194949
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.95,0.0019356836068360628
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.975,0.0026667090170901745
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,04,quantile,0.99,0.0034168905089050805
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.01,8.000000000000014e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.025,0.0015344221942219423
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.05,0.003100000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.1,0.004384125341253415
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.15,0.005373118131181313
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.2,0.005900000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.25,0.006200000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.3,0.0064
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.35,0.006500000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.4,0.006600000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.45,0.006700000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.5,0.0068000000000000005
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.55,0.0069
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.6,0.007
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.65,0.0070999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.7,0.007200000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.75,0.0074
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.8,0.0077
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.85,0.008246600966009663
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.9,0.009218041880418805
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.95,0.01049136911369111
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.975,0.012100000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,05,quantile,0.99,0.012791173401734019
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.2,1.0000000000000113e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.25,2.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.3,3.9999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.35,4.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.4,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.45,6e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.5,6e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.55,6e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.6,6.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.65,7e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.7,8e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.75,9.000000000000005e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.8,0.0010999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.85,0.0013722799727997278
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.9,0.0016214818148181504
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.95,0.002199999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.975,0.002666229787297872
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,06,quantile,0.99,0.0032637243872438745
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.25,1e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.3,1.9999999999999993e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.35,2.0000000000000052e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.4,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.45,3.9999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.5,4e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.55,4.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.6,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.65,6.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.7,6.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.75,8e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.8,0.0010000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.85,0.0014999999999999987
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.9,0.0021999999999999993
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.95,0.0032925796757967496
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.975,0.004912194646946474
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,08,quantile,0.99,0.006010984279842792
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.2,9.486769009248164e-20
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.25,1.0000000000000005e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.3,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.35,2.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.4,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.45,3.9999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.5,4e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.55,4.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.6,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.65,6e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.7,6.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.75,7.000000000000005e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.8,9e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.85,0.001157944029440295
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.9,0.0015
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.95,0.0021232692826928267
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.975,0.0026720960959609554
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,09,quantile,0.99,0.0031001232212322085
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.15,2.0000000000000004e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.2,6.000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.25,9.159534095340958e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.3,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.35,0.0013320687706877066
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.4,0.0015
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.45,0.0016
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.5,0.0017000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.55,0.0018000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.6,0.0019000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.65,0.0021
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.7,0.0022430893308933034
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.75,0.0025
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.8,0.0029
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.85,0.0035
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.9,0.004584736247362464
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.95,0.006406626216262179
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.975,0.008178542710427101
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,10,quantile,0.99,0.009409355403553973
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.15,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.2,6.000000000000004e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.25,9e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.3,0.0010999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.35,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.4,0.0013999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.45,0.0015
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.5,0.0016
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.55,0.0017000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.6,0.0018493128931289285
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.65,0.002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.7,0.0021528514285142804
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.75,0.0023269437694376934
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.8,0.0026000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.85,0.003000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.9,0.0037
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.95,0.0049358128081280804
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.975,0.005709906949069494
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,11,quantile,0.99,0.00677233428334283
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.01,0.003277432274322742
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.025,0.0036000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.05,0.0039
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.1,0.004199999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.15,0.0043
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.2,0.0045
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.25,0.0046
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.3,0.004699999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.35,0.0047
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.4,0.0048
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.45,0.004899999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.5,0.0049
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.55,0.004900000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.6,0.005
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.65,0.0050999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.7,0.0051
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.75,0.0052
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.8,0.0053
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.85,0.0055
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.9,0.005600000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.95,0.0059
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.975,0.006199999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,12,quantile,0.99,0.006514104641046408
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.01,1.000000000000007e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.025,5.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.05,7.999999999999997e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.1,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.15,0.0014999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.2,0.0016999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.25,0.0018
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.3,0.0019
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.35,0.0019999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.4,0.002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.45,0.0020999999999999994
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.5,0.0021
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.55,0.0021000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.6,0.0021999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.65,0.0022
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.7,0.0023
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.75,0.0024
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.8,0.0025
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.85,0.0026999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.9,0.0029999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.95,0.0034000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.975,0.0036999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,13,quantile,0.99,0.0040999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.1,4.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.15,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.2,0.0010000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.25,0.0012
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.3,0.0013284410844108438
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.35,0.0014999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.4,0.0015999999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.45,0.0017
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.5,0.0018
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.55,0.0019
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.6,0.002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.65,0.0021000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.7,0.0022986178861788553
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.75,0.0024000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.8,0.0026
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.85,0.0028
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.9,0.0031571275712757134
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.95,0.003899593095930949
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.975,0.004767488099880995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,15,quantile,0.99,0.006282004720047186
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.35,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.4,6.776263578034403e-20
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.45,1.0000000000000005e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.5,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.55,2.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.6,3.9999999999999986e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.65,5.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.7,7.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.75,9.434589345893441e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.8,0.0013000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.85,0.0019287052370523684
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.9,0.0027000000000000006
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.95,0.00397338953389534
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.975,0.005473996189961892
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,16,quantile,0.99,0.007160640206402048
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.2,9.999999999999994e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.25,2.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.3,3.9999999999999964e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.35,4.243858938589369e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.4,4.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.45,5.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.5,6e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.55,6.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.6,7e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.65,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.7,8.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.75,0.0010582750827508268
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.8,0.001318045180451804
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.85,0.0017900529005290078
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.9,0.0026
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.95,0.003478775287752875
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.975,0.0040999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,17,quantile,0.99,0.004991250382503827
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.2,1e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.25,2.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.3,3.257390573905747e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.35,4.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.4,4.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.45,5.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.5,6e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.55,6.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.6,7e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.65,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.7,8.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.75,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.8,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.85,0.0014999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.9,0.0019999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.95,0.002708631586315861
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.975,0.0034999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,18,quantile,0.99,0.003999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.35,9.620146201461952e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.4,1.962014620146195e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.45,2.9620146201461944e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.5,3e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.55,3.962014620146196e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.6,4.962014620146195e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.65,6.962014620146181e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.7,7.962014620146199e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.75,0.0010962014620146186
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.8,0.0013953376533765343
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.85,0.0018390068900688986
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.9,0.0025962014620146195
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.95,0.0038635494854948587
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.975,0.004796201462014618
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,19,quantile,0.99,0.005529991659916595
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.3,9.999999999999991e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.35,1.0000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.4,1.9999999999999993e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.45,2.9999999999999987e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.5,3e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.55,3.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.6,4.7412374123741196e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.65,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.7,6.000000000000011e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.75,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.8,0.0010424924249242506
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.85,0.0014000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.9,0.0018631578315783184
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.95,0.0029201389013890073
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.975,0.0037859945849458587
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,20,quantile,0.99,0.004488894908949098
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.15,1.9999999999999993e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.2,5.157183571835722e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.25,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.3,9.999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.35,0.0010999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.4,0.0011999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.45,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.5,0.0013
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.55,0.0013999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.6,0.0014749077490774898
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.65,0.0015000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.7,0.0016764156641566373
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.75,0.0018000000000000006
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.8,0.0021000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.85,0.002538439734397341
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.9,0.003297680376803772
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.95,0.0042434332343323404
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.975,0.005099999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,21,quantile,0.99,0.0058928829088290766
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.05,3.1553400534005307e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.1,0.001242666426664267
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.15,0.0017993920939209382
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.2,0.0021000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.25,0.0023000000000000004
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.3,0.0024000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.35,0.0025
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.4,0.0026
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.45,0.0026000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.5,0.0027
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.55,0.0028
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.6,0.0028000000000000004
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.65,0.0029000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.7,0.003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.75,0.0031
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.8,0.0033
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.85,0.0036227727277272775
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.9,0.004167240372403724
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.95,0.005089345943459439
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.975,0.00557474012240122
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,22,quantile,0.99,0.006224953279532791
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.3,2.710505431213761e-20
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.35,1e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.4,1.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.45,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.5,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.55,3e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.6,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.65,4e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.7,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.75,6.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.8,8.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.85,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.9,0.0017999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.95,0.0026000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.975,0.0037167863178631647
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,23,quantile,0.99,0.005321148441484419
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.15,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.2,6.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.25,9.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.3,0.0011
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.35,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.4,0.0013000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.45,0.0013000000000000004
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.5,0.0014000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.55,0.0015
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.6,0.0015000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.65,0.0016000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.7,0.0017000000000000006
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.75,0.0019305870558705583
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.8,0.002235920359203594
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.85,0.0027704240042400446
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.9,0.0034271820718207173
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.95,0.004494845048450485
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.975,0.0049864966399664
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,24,quantile,0.99,0.006087958899588994
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.2,1.3808678086781062e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.25,4.000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.3,6e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.35,7e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.4,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.45,8.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.5,9e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.55,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.6,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.65,0.0011
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.7,0.0012000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.75,0.0014328678286782857
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.8,0.001800171401714029
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.85,0.002337172671726716
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.9,0.003171093010930105
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.95,0.0041849030490304865
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.975,0.004700117026170262
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,25,quantile,0.99,0.005943739437394413
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.3,1e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.35,1.9999999999999993e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.4,1.9999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.45,3e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.5,3e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.55,3.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.6,3.9999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.65,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.7,6.000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.75,8.75834758347584e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.8,0.0012
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.85,0.0015611258112581121
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.9,0.0023
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.95,0.0032853488034880187
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.975,0.004141609416094166
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,26,quantile,0.99,0.0050105021150211
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.2,2.168404344971009e-19
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.25,1.9999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.3,3.9999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.35,5.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.4,7e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.45,7.083690336903367e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.5,8e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.55,9e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.6,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.65,0.0011
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.7,0.0013
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.75,0.0015320110701107002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.8,0.0018999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.85,0.002336990269902697
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.9,0.0027949931499315003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.95,0.003838537735377344
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.975,0.004721116386163867
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,27,quantile,0.99,0.006085569345693462
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.15,1.605856058560586e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.2,3.9999999999999975e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.25,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.3,6.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.35,7e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.4,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.45,8.174569245692467e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.5,9e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.55,9.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.6,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.65,0.0011
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.7,0.0012
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.75,0.0013
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.8,0.0014999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.85,0.0017999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.9,0.0022999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.95,0.0031365673656736604
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.975,0.0036404479294792945
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,28,quantile,0.99,0.004123645306453061
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.35,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.4,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.45,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.5,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.55,9.999999999999998e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.6,1.0000000000000009e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.65,2.0000000000000004e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.7,4e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.75,6.999999999999997e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.8,9.47828478284752e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.85,0.0016999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.9,0.0026000000000000007
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.95,0.003937883628836283
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.975,0.004539259467594678
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,30,quantile,0.99,0.005749490374903778
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.35,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.4,9.999999999999979e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.45,9.999999999999983e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.5,1e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.55,1.9999999999999982e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.6,2.0000000000000015e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.65,2.9999999999999987e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.7,3.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.75,5.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.8,8.266542665426688e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.85,0.0012
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.9,0.0017000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.95,0.002393547435474351
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.975,0.003039685896858971
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,31,quantile,0.99,0.003946744697446964
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.35,9.999999999999998e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.4,9.999999999999999e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.45,1.9999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.5,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.55,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.6,3.999999999999993e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.65,4.8262242622426176e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.7,6.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.75,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.8,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.85,0.0013247644976449782
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.9,0.00196158001580016
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.95,0.002748354933549327
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.975,0.003156600166001658
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,32,quantile,0.99,0.0038177341773417534
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.3,9.999999999999994e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.35,1.9999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.4,2.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.45,3.9999999999999975e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.5,4e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.55,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.6,6.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.65,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.7,9.999999999999992e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.75,0.0012000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.8,0.0015509337093370912
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.85,0.002099999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.9,0.002789825998259985
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.95,0.004159020940209396
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.975,0.0051694031940319315
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,33,quantile,0.99,0.005963095640956419
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.15,3.0000000000000035e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.2,6.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.25,7.907499074990753e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.3,9e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.35,9.896555465554629e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.4,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.45,0.0011
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.5,0.0011
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.55,0.0011000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.6,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.65,0.0012912592125921265
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.7,0.0013000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.75,0.0014709054590545901
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.8,0.0016000000000000007
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.85,0.001932093220932215
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.9,0.0023
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.95,0.0030365706657066592
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.975,0.003578488134881347
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,34,quantile,0.99,0.0039455898158981635
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.35,9.99999999999999e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.4,9.99999999999999e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.45,1.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.5,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.55,2.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.6,3.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.65,5.999999999999997e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.7,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.75,0.0011000000000000007
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.8,0.001615645556455571
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.85,0.0023431030810308106
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.9,0.0035546927469274742
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.95,0.00511553050530503
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.975,0.0075246767717677245
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,35,quantile,0.99,0.009403479524795243
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.15,9.999999999999996e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.2,2.9999999999999894e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.25,4.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.3,5.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.35,6.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.4,6.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.45,7.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.5,7.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.55,7.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.6,8e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.65,8.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.7,9.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.75,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.8,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.85,0.0014000000000000006
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.9,0.0017411979119791206
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.95,0.0024000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.975,0.0029000000000000015
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,36,quantile,0.99,0.0033952489624896236
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.1,9.999999999999929e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.15,4.999999999999991e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.2,7.999999999999995e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.25,0.0010000000000000013
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.3,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.35,0.0013
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.4,0.0014
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.45,0.0014174327743277431
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.5,0.0015
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.55,0.0015999999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.6,0.0016
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.65,0.0017000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.7,0.0018
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.75,0.002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.8,0.0022613804138041393
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.85,0.0025999999999999994
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.9,0.0032
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.95,0.004055040550405495
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.975,0.005063468659686585
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,37,quantile,0.99,0.00626179615796158
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.35,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.4,1.0602706027060264e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.45,1.9999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.5,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.55,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.6,3.9999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.65,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.7,6.694379943799411e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.75,8.999999999999989e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.8,0.0011999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.85,0.0015999999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.9,0.0022365172651726503
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.95,0.004114038890388899
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.975,0.0062
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,38,quantile,0.99,0.007800001890018899
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.2,1.0842021724855044e-19
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.25,1.0000000000000009e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.3,2.0000000000000004e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.35,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.4,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.45,4e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.5,4e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.55,4.0000000000000013e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.6,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.65,5.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.7,6.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.75,7.250027500274982e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.8,9e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.85,0.0011999999999999992
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.9,0.001647032570325703
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.95,0.002400000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.975,0.0029651757767577675
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,39,quantile,0.99,0.003650648996489949
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.3,9.999999999999891e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.35,9.999999999999995e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.4,1.9999999999999993e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.45,2.9999999999999987e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.5,3e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.55,3.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.6,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.65,5.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.7,7.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.75,9e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.8,0.0012
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.85,0.0017000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.9,0.002300000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.95,0.0033465104151041577
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.975,0.00420027322773227
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,40,quantile,0.99,0.004885686986869876
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.25,9.999999999999999e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.3,1.9999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.35,2.0000000000000015e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.4,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.45,3.9999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.5,4e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.55,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.6,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.65,6.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.7,7.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.75,9.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.8,0.0013000000000000004
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.85,0.0016765952659526565
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.9,0.0021620962209622143
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.95,0.0031205412054120525
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.975,0.0036
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,41,quantile,0.99,0.004363676006760051
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.2,1e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.25,2.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.3,3.9999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.35,4.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.4,5e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.45,6e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.5,6e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.55,6.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.6,6.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.65,7e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.7,8e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.75,9.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.8,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.85,0.0014999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.9,0.002056125461254617
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.95,0.0029510129601295993
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.975,0.0034000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,42,quantile,0.99,0.003899999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.15,3.0000000000000035e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.2,6.28571885718859e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.25,8.585688356883567e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.3,9.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.35,0.0010999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.4,0.0012
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.45,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.5,0.0013
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.55,0.0014
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.6,0.0014
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.65,0.0015
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.7,0.0016
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.75,0.0017999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.8,0.002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.85,0.0023999999999999994
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.9,0.0030132712327123274
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.95,0.004061379463794634
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.975,0.004671227837278369
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,44,quantile,0.99,0.005213643636436354
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.025,6.000000000000007e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.05,0.001016432664326643
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.1,0.0017000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.15,0.0020999999999999994
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.2,0.0024
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.25,0.0025999999999999994
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.3,0.0027
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.35,0.0028
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.4,0.0029
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.45,0.0029000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.5,0.003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.55,0.0031
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.6,0.0031000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.65,0.0032
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.7,0.0033
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.75,0.0034000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.8,0.0036000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.85,0.0039000000000000007
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.9,0.0043
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.95,0.004973158681586815
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.975,0.005399999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,45,quantile,0.99,0.0061
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.35,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.4,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.45,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.5,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.55,9.999999999999996e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.6,1.9999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.65,3.455712057120593e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.7,5.25582355823556e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.75,8.3179056790568e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.8,0.0012392083920839225
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.85,0.0016028258282582823
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.9,0.002249116991169915
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.95,0.003129559295592957
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.975,0.004000367428674282
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,46,quantile,0.99,0.0045922254722547155
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.15,1.107241468650782e-18
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.2,2.49785497854979e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.25,4.905111551115487e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.3,6.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.35,7e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.4,7.999999999999999e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.45,8.362128121281217e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.5,9e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.55,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.6,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.65,0.0011
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.7,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.75,0.0013999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.8,0.0016068310683106848
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.85,0.0020064539645396444
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.9,0.0024999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.95,0.0030184767847678457
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.975,0.0037129832298322977
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,47,quantile,0.99,0.0043651746817468095
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.05,4.999999999999987e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.1,0.0012000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.15,0.0016000000000000007
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.2,0.0019999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.25,0.0022000000000000006
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.3,0.0024000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.35,0.0025
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.4,0.0026
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.45,0.0026000000000000007
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.5,0.0027
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.55,0.0027999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.6,0.0028000000000000004
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.65,0.0029000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.7,0.003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.75,0.0031999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.8,0.0034000000000000007
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.85,0.0037999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.9,0.0042
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.95,0.004919347693476925
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.975,0.005536141611416112
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,48,quantile,0.99,0.006086641536415361
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.35,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.4,9.999999999999984e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.45,9.999999999999986e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.5,1e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.55,1.9999999999999987e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.6,2.9999999999999976e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.65,3.9999999999999975e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.7,5.267564675646764e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.75,8.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.8,0.0012324059240592445
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.85,0.0018000000000000006
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.9,0.0026000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.95,0.003981417814178138
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.975,0.0058000000000000005
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,49,quantile,0.99,0.0072851958619586194
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.35,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.4,2.981555974335137e-19
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.45,1.0000000000000005e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.5,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.55,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.6,4.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.65,5.999999999999993e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.7,7.434101341013367e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.75,9.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.8,0.0013051364513645201
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.85,0.0019999999999999983
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.9,0.003088079680796815
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.95,0.004560711007110055
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.975,0.0057469461944619485
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,50,quantile,0.99,0.0072257332673326714
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.025,4.0724657246576204e-6
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.05,4.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.1,8.662693626936269e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.15,0.0012
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.2,0.001481359213592135
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.25,0.0016069430694306947
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.3,0.0017999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.35,0.0018000000000000004
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.4,0.0019
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.45,0.0019999999999999996
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.5,0.002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.55,0.0020000000000000005
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.6,0.0021
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.65,0.0021999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.7,0.0022000000000000006
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.75,0.0024
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.8,0.0025180553805538085
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.85,0.0028000000000000004
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.9,0.0031463325633256396
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.95,0.0036
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.975,0.004081708317083167
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,51,quantile,0.99,0.004596329673296729
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.15,4.336808689942018e-19
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.2,3.0924009240092417e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.25,6.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.3,8.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.35,9.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.4,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.45,0.0010999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.5,0.0011
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.55,0.0011999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.6,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.65,0.0013000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.7,0.0014000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.75,0.001600000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.8,0.0019999999999999987
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.85,0.0023650186501865
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.9,0.0029027206272062753
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.95,0.0040999999999999995
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.975,0.0054650886508865095
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,53,quantile,0.99,0.006666243662436629
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.2,1.5996959969597528e-5
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.25,3.0000000000000024e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.3,6.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.35,8.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.4,9.000000000000002e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.45,0.0010000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.5,0.0011
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.55,0.0012000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.6,0.0013000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.65,0.0014999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.7,0.0017000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.75,0.0021999999999999997
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.8,0.0028636958369583714
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.85,0.0035698038480384765
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.9,0.004448563985639868
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.95,0.006441523665236631
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.975,0.007943206857068594
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,54,quantile,0.99,0.009482076510764976
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.3,1.0842021724855044e-19
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.35,1e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.4,1.0000000000000005e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.45,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.5,2e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.55,3e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.6,3.0000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.65,4e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.7,5.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.75,7.999999999999998e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.8,0.001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.85,0.0013999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.9,0.0019192263922639247
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.95,0.002699753947539473
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.975,0.003000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,55,quantile,0.99,0.0036493264932649307
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.1,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.15,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.2,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.25,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.3,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.35,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.4,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.45,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.5,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.55,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.6,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.65,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.7,3e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.75,7.000000000000001e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.8,0.001152329523295237
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.85,0.002001972769727697
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.9,0.0031080352803528047
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.95,0.004939183641836418
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.975,0.006949258742587418
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,56,quantile,0.99,0.009048004730047321
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.01,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.025,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.05,0
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.1,4.000000000000006e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.15,7.000000000000003e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.2,9.999999999999996e-4
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.25,0.0011000000000000003
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.3,0.0012000000000000014
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.35,0.0013000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.4,0.0014
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.45,0.0014999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.5,0.0015
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.55,0.0015000000000000002
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.6,0.0016
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.65,0.0017
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.7,0.001799999999999999
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.75,0.0018999999999999998
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.8,0.002000000000000001
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.85,0.0023
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.9,0.0026
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.95,0.003069714997149972
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.975,0.003393243457434572
+2025-11-22,1,wk inc rsv prop ed visits,2025-11-29,US,quantile,0.99,0.003993850928509282
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.025,1.8497584975849437e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.05,6.856508065080642e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.1,0.0014527809278092778
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.15,0.001900000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.2,0.0023
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.25,0.0026
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.3,0.0028
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.35,0.0029999999999999996
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.4,0.0031
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.45,0.0031999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.5,0.0033
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.55,0.0034000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.6,0.0035
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.65,0.0036000000000000008
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.7,0.0038
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.75,0.004
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.8,0.0043
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.85,0.0046999999999999984
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.9,0.005142693326933271
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.95,0.005916070160701605
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.975,0.006599999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,01,quantile,0.99,0.007247418284182848
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.4,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.45,1.9999999999999993e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.5,4e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.55,6.460406104061055e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.6,9.266034660346587e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.65,0.0012999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.7,0.001738737387373875
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.75,0.002277593525935258
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.8,0.002909994099941004
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.85,0.003662009120091198
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.9,0.004502265822658234
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.95,0.005813856688566886
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.975,0.006975092925929257
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,02,quantile,0.99,0.008485336703367024
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.35,2.962164621646147e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.4,9.999999999999995e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.45,1.9999999999999993e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.5,2e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.55,2.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.6,3.9999999999999986e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.65,4.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.7,6.000000000000002e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.75,8.272055220552197e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.8,0.0010999999999999998
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.85,0.0013857525075250722
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.9,0.0017053950539505371
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.95,0.0024079737797377846
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.975,0.0031096727967279657
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,04,quantile,0.99,0.0037181089310893067
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.01,1.0046926469264697e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.025,0.0010000000000000018
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.05,0.0021990983409834086
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.1,0.0036999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.15,0.004566323763237631
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.2,0.005314930349303495
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.25,0.0058000000000000005
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.3,0.006104900749007489
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.35,0.0063999999999999994
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.4,0.0065000000000000014
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.45,0.0067
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.5,0.0068000000000000005
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.55,0.006900000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.6,0.0070999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.65,0.007208868088680885
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.7,0.0075
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.75,0.0078000000000000005
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.8,0.008299999999999998
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.85,0.009051526815268163
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.9,0.009900000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.95,0.011383298582985833
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.975,0.012578875338753391
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,05,quantile,0.99,0.013493248732487324
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.25,1.0000000000000026e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.3,2.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.35,3.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.4,4.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.45,5.928760287602882e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.5,6e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.55,6.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.6,7.000000000000002e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.65,8.000000000000007e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.7,9.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.75,0.0011460992109921112
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.8,0.0013771621716217133
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.85,0.0016000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.9,0.002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.95,0.0025119181191811755
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.975,0.003017254872548723
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,06,quantile,0.99,0.003687459064590628
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.3,9.999999999999963e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.35,1.9999999999999982e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.4,2.9999999999999943e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.45,3.149463494634955e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.5,4e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.55,5e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.6,6.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.65,7.000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.7,9e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.75,0.0011000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.8,0.0015320035200352012
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.85,0.0020802616526165263
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.9,0.002699652296522965
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.95,0.004267167771677705
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.975,0.005408147081470815
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,08,quantile,0.99,0.00682390909909099
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.3,1.0000000000000002e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.35,2e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.4,3e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.45,3.405949559495601e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.5,4e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.55,5e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.6,6e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.65,6.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.7,7.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.75,9.391426414264153e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.8,0.0011989619896198983
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.85,0.0014577398773987734
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.9,0.0018700946009460124
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.95,0.0025097940979409844
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.975,0.002960541730417298
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,09,quantile,0.99,0.003497075190751913
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.2,1.5056810568105734e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.25,5.317915679156794e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.3,8.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.35,0.0011416054660546599
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.4,0.0013999999999999996
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.45,0.0015359240092400945
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.5,0.0017000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.55,0.0019000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.6,0.0021000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.65,0.0023000000000000004
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.7,0.0026000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.75,0.003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.8,0.0035754581545815473
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.85,0.0043751427014270105
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.9,0.005690849608496078
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.95,0.007613185131851321
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.975,0.008937210422104224
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,10,quantile,0.99,0.01040002385023849
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.2,2.9999999999999976e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.25,6e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.3,8.392376923769232e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.35,0.0010999999999999996
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.4,0.001295811358113585
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.45,0.001411850968509684
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.5,0.0016
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.55,0.0018
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.6,0.002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.65,0.0021999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.7,0.0024000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.75,0.0027
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.8,0.003065913859138596
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.85,0.0035999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.9,0.004399999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.95,0.005511658266582661
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.975,0.006499999999999998
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,11,quantile,0.99,0.007644293852938507
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.01,0.003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.025,0.003371576915769158
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.05,0.003685603956039561
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.1,0.004
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.15,0.0042
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.2,0.004300000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.25,0.004499999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.3,0.004599999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.35,0.004699999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.4,0.00476788147881479
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.45,0.0048000000000000004
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.5,0.0049
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.55,0.004999999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.6,0.0050201952019520175
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.65,0.0051
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.7,0.005200000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.75,0.005300000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.8,0.005499999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.85,0.0056
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.9,0.0058
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.95,0.006116497264972649
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.975,0.00642520992709927
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,12,quantile,0.99,0.0068
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.025,2.0000000000000096e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.05,5.999999999999996e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.1,9.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.15,0.0012999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.2,0.0014999999999999998
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.25,0.0016703722037220373
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.3,0.0017999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.35,0.0018999999999999998
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.4,0.0019999999999999996
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.45,0.002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.5,0.0021
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.55,0.0021999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.6,0.0022
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.65,0.0023
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.7,0.0024
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.75,0.002519514445144451
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.8,0.0026999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.85,0.0029000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.9,0.0032
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.95,0.0036000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.975,0.003999999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,13,quantile,0.99,0.004399999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.1,9.999999999999994e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.15,4.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.2,7.999999999999996e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.25,0.001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.3,0.0012
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.35,0.0013999999999999987
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.4,0.0015
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.45,0.0016929862798627981
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.5,0.0018
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.55,0.00195978359783598
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.6,0.0021
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.65,0.00228588430884309
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.7,0.0024000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.75,0.0026000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.8,0.0028336269362693647
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.85,0.0031329199791997903
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.9,0.0036
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.95,0.004474233542335412
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.975,0.005483972689726919
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,15,quantile,0.99,0.007091180651806511
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.4,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.45,9.999999999999988e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.5,2e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.55,3.9999999999999986e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.6,5.999999999999997e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.65,7.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.7,0.0010999999999999994
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.75,0.0014639338893388946
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.8,0.0019883776837768437
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.85,0.0026
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.9,0.003344817748177489
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.95,0.005051405664056654
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.975,0.006558354608546087
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,16,quantile,0.99,0.008383477964779638
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.25,4.87890977618477e-19
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.3,1.9999999999999993e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.35,3.0049740497404865e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.4,4.59763997639978e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.45,5.000000000000004e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.5,6e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.55,7e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.6,8e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.65,9.240913409134084e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.7,0.0011111483114831136
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.75,0.001400000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.8,0.0018000000000000004
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.85,0.0024436564365643647
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.9,0.0030082666826668322
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.95,0.003879936449364491
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.975,0.004776428764287571
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,17,quantile,0.99,0.005891845408454123
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.25,9.999999999999983e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.3,2.0000000000000004e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.35,3.000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.4,4.0000000000000127e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.45,5.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.5,6e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.55,7e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.6,7.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.65,9e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.7,0.0010999999999999996
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.75,0.0012999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.8,0.0015000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.85,0.0018999999999999996
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.9,0.002398913189131893
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.95,0.0031999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.975,0.0038
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,18,quantile,0.99,0.004407515875158739
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.4,1.2143064331838439e-18
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.45,1.9999999999999982e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.5,3e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.55,4.000000000000013e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.6,6.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.65,8.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.7,0.001096763767637673
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.75,0.0013999999999999996
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.8,0.0018018592185921891
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.85,0.0024000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.9,0.003182772327723278
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.95,0.004464492094920953
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.975,0.005213488584885837
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,19,quantile,0.99,0.006242621846218408
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.35,6.195111951119459e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.4,1.6195111951119453e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.45,2.619511195111941e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.5,3e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.55,3.916181161811589e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.6,5.619511195111941e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.65,6.619511195111946e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.7,8.619511195111945e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.75,0.001061951119511195
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.8,0.0013809053090530936
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.85,0.0017619511195111947
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.9,0.002361951119511195
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.95,0.0034541724917249105
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.975,0.004194945974459752
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,20,quantile,0.99,0.005037831008310082
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.2,1.9999999999999987e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.25,4.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.3,7.650872508725076e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.35,9.048556985569859e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.4,0.0010999999999999998
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.45,0.0012
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.5,0.0013
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.55,0.0014000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.6,0.0015676418764187664
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.65,0.0017000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.7,0.0019
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.75,0.0021999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.8,0.002579281792817926
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.85,0.0030999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.9,0.0037999999999999987
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.95,0.004833297482974828
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.975,0.005599999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,21,quantile,0.99,0.006716641166411614
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.05,3.680166801668129e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.1,7.263626636266357e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.15,0.0013275351753517502
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.2,0.0017466024660246606
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.25,0.002025055500555006
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.3,0.0022625226252262496
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.35,0.0024000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.4,0.0025000000000000005
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.45,0.0026000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.5,0.0027
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.55,0.0028
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.6,0.0029000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.65,0.003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.7,0.0031529415294152914
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.75,0.0033849540995409926
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.8,0.0036583093830938338
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.85,0.00407554540545405
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.9,0.004692978929789304
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.95,0.0054
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.975,0.006034480469804694
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,22,quantile,0.99,0.006880301013010125
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.4,5.796757967579815e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.45,1.5796757967579813e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.5,2e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.55,2.5796757967579825e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.6,3.579675796757982e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.65,4.5796757967579867e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.7,6.579675796757981e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.75,8.579675796757982e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.8,0.0012369691696917002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.85,0.0016579675796757982
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.9,0.0021579675796757985
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.95,0.0034579675796757975
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.975,0.00455888411384112
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,23,quantile,0.99,0.005582251702517025
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.2,2.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.25,5.706564565645657e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.3,8.061979619796182e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.35,0.0010053117531175328
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.4,0.0012000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.45,0.0013000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.5,0.0014000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.55,0.0015000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.6,0.0016000000000000007
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.65,0.0018000000000000004
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.7,0.002000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.75,0.0023222204722047226
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.8,0.002774067940679415
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.85,0.0033
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.9,0.004
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.95,0.004865923709237089
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.975,0.005728221432214279
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,24,quantile,0.99,0.006853034080340843
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.25,1.0000000000000026e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.3,3.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.35,5.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.4,7e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.45,8e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.5,9e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.55,0.001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.6,0.0011000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.65,0.0013000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.7,0.0015875498754987548
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.75,0.0019000000000000006
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.8,0.002384226842268424
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.85,0.0030000000000000005
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.9,0.0037
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.95,0.004600000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.975,0.0055529859548595585
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,25,quantile,0.99,0.0068000000000000005
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.35,9.999999999999976e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.4,1.9999999999999977e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.45,2.9999999999999965e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.5,3e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.55,3.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.6,5.307321073210728e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.65,6.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.7,9.601857018570197e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.75,0.0012864613646136444
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.8,0.0016072294722947241
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.85,0.0021814165141651413
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.9,0.002862723327233277
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.95,0.003836883118831187
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.975,0.00481605646056461
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,26,quantile,0.99,0.005819204662046571
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.3,1.9999999999999985e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.35,3.9999999999999986e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.4,5.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.45,7e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.5,8e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.55,9.999999999999996e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.6,0.0011324439244392414
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.65,0.001399999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.7,0.0016000000000000007
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.75,0.0019427656776567776
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.8,0.0023213698136981377
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.85,0.002709835048350486
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.9,0.003399999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.95,0.004457994029940305
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.975,0.005537443699436989
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,27,quantile,0.99,0.0069121244512445
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.2,1.0000000000000034e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.25,3.0000000000000046e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.3,5e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.35,6.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.4,7.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.45,8e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.5,9e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.55,0.001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.6,0.0011
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.65,0.0012000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.7,0.0013068647686476842
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.75,0.0015000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.8,0.0018
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.85,0.0022
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.9,0.0027999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.95,0.0034983399833998304
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.975,0.004000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,28,quantile,0.99,0.004632415974159735
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.4,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.45,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.5,7.950079500756513e-8
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.55,1.2154421544215399e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.6,2.2154421544215414e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.65,4.3786782867828754e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.7,7.215442154421539e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.75,0.0011215442154421523
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.8,0.0017215442154421537
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.85,0.0024288394883948865
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.9,0.003211242012420122
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.95,0.004321544215442154
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.975,0.005398053530535302
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,30,quantile,0.99,0.006615779387793871
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.4,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.45,2.710505431213761e-20
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.5,1e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.55,1.999999999999997e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.6,2.9999999999999943e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.65,4e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.7,6e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.75,8.000000000000005e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.8,0.0011000000000000014
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.85,0.0015194079440794379
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.9,0.001995210652106525
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.95,0.002800000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.975,0.003543878138781374
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,31,quantile,0.99,0.004538656856568576
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.4,4.0657581468206416e-20
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.45,1.0000000000000005e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.5,2e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.55,3.0000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.6,4.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.65,5.853377033770347e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.7,7.466604666046695e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.75,9.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.8,0.0012999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.85,0.0017562455124551226
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.9,0.0022999999999999987
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.95,0.0029835860858608504
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.975,0.003576491589915889
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,32,quantile,0.99,0.004397006730067293
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.4,1.0000000000000005e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.45,2.443973939739412e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.5,4e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.55,5.010617106171034e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.6,7.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.65,9.512353123531233e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.7,0.0012000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.75,0.0015924226742267417
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.8,0.002000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.85,0.0026
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.9,0.003500000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.95,0.004818609486094855
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.975,0.005677761227612273
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,33,quantile,0.99,0.006825437384373834
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.15,5.7638826388264364e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.2,3.000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.25,5.55835058350583e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.3,7.000000000000002e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.35,8.397751977519769e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.4,9.635118351183525e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.45,0.001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.5,0.0011
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.55,0.0012000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.6,0.0013
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.65,0.0013999999999999998
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.7,0.0015
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.75,0.0017
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.8,0.0019306961069610676
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.85,0.002250192901929019
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.9,0.0027000000000000006
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.95,0.00338627306273063
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.975,0.0038716412164121585
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,34,quantile,0.99,0.004397560075600755
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.4,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.45,9.999999999999999e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.5,2e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.55,3.7377143771437815e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.6,5.812290122901229e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.65,8.062827128271315e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.7,0.0012000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.75,0.0017000000000000012
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.8,0.002318207982079821
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.85,0.0032940602906029043
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.9,0.0042991454914549174
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.95,0.0065184061840618274
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.975,0.008691797642976416
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,35,quantile,0.99,0.009905981549815498
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.2,9.999999999999983e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.25,2.1288237882378792e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.3,4e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.35,5e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.4,6.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.45,6.568890688906904e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.5,7.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.55,8e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.6,8.000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.65,9.000000000000002e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.7,0.0010281693816938159
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.75,0.0012000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.8,0.0014000000000000009
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.85,0.0017000000000000006
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.9,0.0020625163251632517
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.95,0.002696837968379686
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.975,0.003264049840498406
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,36,quantile,0.99,0.0037034220842208417
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.15,1e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.2,4.7572895728957435e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.25,7.152801528015279e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.3,9.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.35,0.0012
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.4,0.0013
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.45,0.0014
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.5,0.0015
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.55,0.0016
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.6,0.0017000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.65,0.0018622562225622248
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.7,0.0020432602326023236
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.75,0.0023
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.8,0.0026
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.85,0.003059951049510494
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.9,0.0037
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.95,0.004663900189001891
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.975,0.005827749052490518
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,37,quantile,0.99,0.00661095446954469
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.4,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.45,9.999999999999999e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.5,2e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.55,3.0000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.6,4.696556965569657e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.65,6.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.7,8.793664936649355e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.75,0.0011999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.8,0.0015576903769037723
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.85,0.0021
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.9,0.0030897683976839783
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.95,0.005157480024800245
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.975,0.006954034815348143
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,38,quantile,0.99,0.00871240014400144
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.3,1.0000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.35,2.0000000000000004e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.4,3.0000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.45,3.9999999999999964e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.5,4e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.55,5e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.6,5.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.65,6.999999999999997e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.7,7.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.75,9.420059200592008e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.8,0.0012000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.85,0.0015608869588695918
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.9,0.0021000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.95,0.002762993629936295
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.975,0.003371545440454403
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,39,quantile,0.99,0.00407549867498675
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.4,5.932259322593226e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.45,1.9999999999999939e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.5,3e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.55,4.0000000000000013e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.6,5.000000000000002e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.65,7.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.7,9.000000000000002e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.75,0.0012000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.8,0.0016000000000000022
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.85,0.0021049143491434913
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.9,0.0027885044850448552
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.95,0.003839947649476499
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.975,0.004599999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,40,quantile,0.99,0.005497311013110129
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.35,1.7047885478854792e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.4,2.9993079930799274e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.45,3.5580475804758134e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.5,4e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.55,5e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.6,6.643546435464354e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.65,7.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.7,0.0010999999999999996
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.75,0.0013999999999999983
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.8,0.0016999999999999986
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.85,0.0020906863068630662
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.9,0.0027488683886838765
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.95,0.0034818102181021827
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.975,0.00417409184091841
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,41,quantile,0.99,0.0050999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.25,9.999999999999994e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.3,2.4921629216291893e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.35,3.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.4,4.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.45,5.796458964589654e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.5,6e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.55,6.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.6,7.392285922859232e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.65,8.999999999999991e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.7,0.0010000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.75,0.001293692186921866
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.8,0.0015
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.85,0.00190942724427244
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.9,0.0025082870828708284
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.95,0.0032859570595705906
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.975,0.0037876644766447667
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,42,quantile,0.99,0.004400000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.2,3.0000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.25,5.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.3,7.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.35,9.999999999999996e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.4,0.0010999999999999998
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.45,0.0012
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.5,0.0013
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.55,0.0014
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.6,0.0015
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.65,0.0016999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.7,0.0018000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.75,0.002073707987079871
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.8,0.0024000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.85,0.0029
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.9,0.003569010690106898
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.95,0.004496232612326115
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.975,0.0050885458854588545
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,44,quantile,0.99,0.005850035910359089
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.025,1.527532525325254e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.05,7.000000000000005e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.1,0.0013321627216272165
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.15,0.001799999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.2,0.0020999999999999994
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.25,0.002300000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.3,0.0025000000000000005
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.35,0.0026999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.4,0.0028
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.45,0.0029000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.5,0.003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.55,0.0031
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.6,0.0032
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.65,0.0033000000000000004
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.7,0.0034999999999999996
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.75,0.0036999999999999993
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.8,0.0039000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.85,0.004200000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.9,0.004651217912179124
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.95,0.0053
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.975,0.0058755356053560494
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,45,quantile,0.99,0.0067
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.4,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.45,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.5,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.55,1.1459924599246108e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.6,3.0000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.65,5.624618746187442e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.7,8.809020090200843e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.75,0.0012017857678576756
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.8,0.0015999999999999994
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.85,0.002099999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.9,0.002779638696386967
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.95,0.003742275572755728
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.975,0.004467094095940956
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,46,quantile,0.99,0.00549915651156511
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.25,2.0000000000000052e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.3,4.000000000000005e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.35,5.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.4,7.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.45,8e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.5,9e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.55,0.001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.6,0.0011000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.65,0.0012999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.7,0.0014685879858798568
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.75,0.0017
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.8,0.002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.85,0.0023999999999999994
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.9,0.0027999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.95,0.0034999999999999996
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.975,0.004188005455054568
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,47,quantile,0.99,0.004970502255022544
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.05,7.826398263982631e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.1,7.999999999999994e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.15,0.0012982091320913184
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.2,0.0016000000000000012
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.25,0.001900000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.3,0.0021999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.35,0.0023895445954459542
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.4,0.0025
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.45,0.0026000000000000003
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.5,0.0027
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.55,0.0028
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.6,0.0029000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.65,0.003015186951869517
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.7,0.0032000000000000006
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.75,0.003495839708397083
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.8,0.003793218732187317
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.85,0.004112030420304196
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.9,0.004600059300593012
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.95,0.005386309263092627
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.975,0.005943053855538547
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,48,quantile,0.99,0.006700000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.4,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.45,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.5,1e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.55,2.0000000000000004e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.6,3.2116001160011596e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.65,5.648067980679817e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.7,8.666423664236621e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.75,0.001287364873648738
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.8,0.001777416574165738
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.85,0.002399999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.9,0.0034000000000000007
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.95,0.005002374523745246
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.975,0.006653730837308346
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,49,quantile,0.99,0.008384796727967265
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.4,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.45,1.6263032587282567e-19
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.5,2e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.55,3.04256592565928e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.6,5.000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.65,7.752349023490244e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.7,0.0010105627056270577
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.75,0.0014187849378493795
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.8,0.0020004188041880503
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.85,0.0028090331403314043
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.9,0.0037935159351593526
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.95,0.0052999999999999966
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.975,0.006623793212932141
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,50,quantile,0.99,0.008507480164801653
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.05,1e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.1,5.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.15,9.091480914809155e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.2,0.0012000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.25,0.0014000000000000006
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.3,0.0016
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.35,0.0017000000000000008
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.4,0.0018000000000000006
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.45,0.0019
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.5,0.002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.55,0.0021
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.6,0.0021999999999999997
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.65,0.0022999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.7,0.0024000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.75,0.0026
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.8,0.0028
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.85,0.0030999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.9,0.0034000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.95,0.003921159161591612
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.975,0.004454729147291469
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,51,quantile,0.99,0.00498489790897909
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.2,4.0657581468206416e-20
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.25,3.0000000000000003e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.3,5.99999999999997e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.35,7.999999999999995e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.4,9.000000000000001e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.45,0.001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.5,0.0011
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.55,0.0012000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.6,0.0013000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.65,0.0015
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.7,0.0017000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.75,0.0020497797477974783
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.8,0.0024
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.85,0.002840626156261563
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.9,0.0036965349653496557
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.95,0.005000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.975,0.006158596010960108
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,53,quantile,0.99,0.007042639936399343
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.3,2.0539005390053858e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.35,5.259847598475986e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.4,7.259847598475987e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.45,9.259847598475986e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.5,0.0010999999999999998
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.55,0.0012259847598475987
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.6,0.0014479009790097908
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.65,0.001810314203142031
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.7,0.002276535065350649
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.75,0.0028640088900888953
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.8,0.0035259847598475957
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.85,0.004248711137111368
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.9,0.005474096740967419
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.95,0.007460774907749063
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.975,0.008892771777717762
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,54,quantile,0.99,0.011392545615456082
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.4,5.471254712547084e-5
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.45,1.5471254712547084e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.5,2e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.55,2.5471254712547116e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.6,4.514219142191421e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.65,5.783498334983347e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.7,7.616286162861618e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.75,0.0010341358413584112
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.8,0.0013547125471254711
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.85,0.0017683444334443354
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.9,0.0023371273712737123
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.95,0.0029225754757547565
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.975,0.003478697336973366
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,55,quantile,0.99,0.004274682216822161
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.1,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.15,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.2,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.25,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.3,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.35,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.4,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.45,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.5,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.55,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.6,2.4001840018399883e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.65,4.999999999999999e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.7,8.58816488164878e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.75,0.0013
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.8,0.0020777147771477754
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.85,0.0029294265442654415
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.9,0.004309891098910976
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.95,0.006112765827658249
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.975,0.007870709507095069
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,56,quantile,0.99,0.010649109801097898
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.01,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.025,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.05,0
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.1,1.9999999999999922e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.15,4.999999999999998e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.2,7.000000000000006e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.25,9.060595605956067e-4
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.3,0.0010999999999999998
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.35,0.0012000000000000001
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.4,0.0013000000000000004
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.45,0.0014000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.5,0.0015
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.55,0.0015999999999999999
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.6,0.0017
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.65,0.0018
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.7,0.0019000000000000002
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.75,0.0020999999999999994
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.8,0.0022999999999999995
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.85,0.0025000000000000005
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.9,0.0028592429924299244
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.95,0.0033
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.975,0.0037867140671406607
+2025-11-22,2,wk inc rsv prop ed visits,2025-12-06,US,quantile,0.99,0.0043
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.05,3.0537405374053537e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.1,0.0011335442354423522
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.15,0.0016390890908909096
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.2,0.002022418024180242
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.25,0.0023737699876998776
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.3,0.0026000000000000007
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.35,0.0028202938529385303
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.4,0.003
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.45,0.0031999999999999993
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.5,0.0033
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.55,0.0034135028850288502
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.6,0.0036
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.65,0.0037849503995039946
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.7,0.0039996331963319635
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.75,0.0042201802018020165
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.8,0.004580725007250077
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.85,0.004954388243882439
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.9,0.005485833458334587
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.95,0.006287469874698747
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.975,0.006961841843418431
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,01,quantile,0.99,0.007811308693086941
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.45,9.568655686556795e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.5,4e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.55,7.00000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.6,0.0011000000000000003
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.65,0.0015570001700017037
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.7,0.0020731085310853052
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.75,0.0026524065240652395
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.8,0.0033151753517535153
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.85,0.004099999999999998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.9,0.005047226172261723
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.95,0.0065000000000000014
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.975,0.00786187626876268
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,02,quantile,0.99,0.009511394663946649
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.4,1.8513685136851933e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.45,1.1851368513685179e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.5,2e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.55,2.799997499975002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.6,4.185136851368517e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.65,5.185136851368522e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.7,7.185136851368521e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.75,9.320073200732039e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.8,0.0012185136851368514
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.85,0.0015185136851368513
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.9,0.001918513685136852
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.95,0.002688647836478347
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.975,0.0033275164001640035
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,04,quantile,0.99,0.004026557795577946
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.025,5.82827978279783e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.05,0.0015499329493294939
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.1,0.003137512075120753
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.15,0.0040560635106351075
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.2,0.0048
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.25,0.005400000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.3,0.005816733467334672
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.35,0.006199999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.4,0.006400000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.45,0.006600000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.5,0.0068000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.55,0.007
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.6,0.0072
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.65,0.007400639656396566
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.7,0.007759088790887908
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.75,0.0082
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.8,0.008808658486584872
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.85,0.009520291152911527
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.9,0.010481637516375167
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.95,0.012059446844468438
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.975,0.013058588885888855
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,05,quantile,0.99,0.014549949549495496
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.3,1.7616206162061613e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.35,3.0000000000000003e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.4,4.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.45,5e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.5,6e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.55,7e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.6,8e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.65,9.612710127101271e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.7,0.0011
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.75,0.0013
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.8,0.0015311267112671132
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.85,0.0018290345403453997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.9,0.0021999999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.95,0.002799999999999998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.975,0.0033558965589655853
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,06,quantile,0.99,0.004033671236712366
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.35,8.000230002299956e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.4,1.8000230002299968e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.45,2.800023000229999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.5,4.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.55,5.800023000229991e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.6,6.800023000229998e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.65,8.800023000229995e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.7,0.001080002300023
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.75,0.0014461919619196185
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.8,0.0018983232832328392
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.85,0.002427134321343208
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.9,0.0032262097620976223
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.95,0.004843230282302814
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.975,0.005966174536745364
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,08,quantile,0.99,0.007335405804058049
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.35,9.999999999999999e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.4,2.0000000000000015e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.45,3.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.5,4e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.55,5e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.6,6.165925659256575e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.65,7.999999999999997e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.7,9.000000000000004e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.75,0.0011000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.8,0.0013999999999999996
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.85,0.0016999999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.9,0.0021000000000000003
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.95,0.0027562559125591172
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.975,0.003262526700267008
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,09,quantile,0.99,0.0039140169801697945
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.25,1.8713137131370992e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.3,5.871313713137099e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.35,9.388192881928774e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.4,0.0012139164391643904
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.45,0.0014871313713137099
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.5,0.0017000000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.55,0.00198713137131371
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.6,0.002238350883508831
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.65,0.002578888438884385
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.7,0.0029764081640816288
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.75,0.003475886758867586
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.8,0.00413929149291493
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.85,0.0051128093280932724
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.9,0.0063452337523375235
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.95,0.008286858418584174
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.975,0.009658836663366617
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,10,quantile,0.99,0.011476130141301394
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.25,3.000000000000021e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.3,6.341827418274163e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.35,8.999999999999999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.4,0.0011972211722117226
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.45,0.0013999999999999998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.5,0.0016
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.55,0.001854217392173921
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.6,0.0020999999999999994
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.65,0.00234418764187642
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.7,0.0026364423644236424
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.75,0.0029999999999999996
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.8,0.0034624038240382445
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.85,0.004056253862538625
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.9,0.004870513605136057
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.95,0.006031047760477595
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.975,0.0070970923209232135
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,11,quantile,0.99,0.008393134181341806
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.01,0.002768105071050709
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.025,0.003153404009040091
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.05,0.0034999999999999988
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.1,0.0038146138461384624
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.15,0.004099999999999998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.2,0.004218803188031882
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.25,0.004399999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.3,0.0045
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.35,0.0046
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.4,0.0047
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.45,0.0048
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.5,0.0049
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.55,0.004999999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.6,0.0050999999999999995
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.65,0.0052
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.7,0.0053
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.75,0.0054
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.8,0.005594776347763476
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.85,0.005700000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.9,0.005973724937249376
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.95,0.006300000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.975,0.006667789677896781
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,12,quantile,0.99,0.007036890428904282
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.05,3.999999999999994e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.1,8e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.15,0.0011
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.2,0.0013403388033880336
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.25,0.0015000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.3,0.0016999999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.35,0.0018
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.4,0.0019
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.45,0.002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.5,0.0021
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.55,0.0021999999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.6,0.0022999999999999995
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.65,0.0024
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.7,0.0025
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.75,0.00269289292892929
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.8,0.002855174351743518
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.85,0.0030999999999999995
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.9,0.0034
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.95,0.003809298892988933
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.975,0.004212798902989046
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,13,quantile,0.99,0.004699999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.15,2.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.2,5.465602656026587e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.25,8.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.3,0.0010420583205832021
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.35,0.0012730025300252998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.4,0.0014435906359063582
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.45,0.0016000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.5,0.0018
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.55,0.002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.6,0.0021999999999999993
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.65,0.002366283662836628
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.7,0.002589296992969928
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.75,0.0028
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.8,0.0030999999999999995
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.85,0.0034220968709687037
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.9,0.003971030810308101
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.95,0.004982622776227759
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.975,0.006105135776357764
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,15,quantile,0.99,0.0075760044800448085
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.45,2.710505431213761e-20
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.5,2e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.55,4.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.6,6.531577315773176e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.65,9.644463944639479e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.7,0.0013091127911279113
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.75,0.0017999999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.8,0.0023437466374663786
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.85,0.002959916949169491
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.9,0.0039426275262752645
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.95,0.005662374173741728
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.975,0.007224252967529677
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,16,quantile,0.99,0.009248024780247797
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.3,1.6729667296672507e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.35,1.9999999999999944e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.4,3.99999999999999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.45,4.999999999999991e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.5,6e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.55,7.999999999999986e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.6,8.999999999999992e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.65,0.0010999999999999996
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.7,0.0013999999999999991
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.75,0.0017585665856658579
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.8,0.002242011420114208
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.85,0.00277262702627026
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.9,0.0033999999999999985
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.95,0.004388754337543379
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.975,0.005332690751907522
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,17,quantile,0.99,0.006556609586095828
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.3,9.999999999999961e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.35,2.49704947049469e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.4,3.999999999999996e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.45,4.999999999999997e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.5,6e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.55,7.756882568825695e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.6,8.999999999999995e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.65,0.0010461481114811134
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.7,0.0012371979719797183
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.75,0.0014999999999999992
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.8,0.001799999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.85,0.002199999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.9,0.002706641666416665
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.95,0.003529612696126971
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.975,0.004136816493164928
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,18,quantile,0.99,0.004935357893578935
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.45,1.6229722297223025e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.5,3.0000000000000003e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.55,5.10873708737089e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.6,7.956599565995636e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.65,0.0010086301863018606
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.7,0.0013507524075240759
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.75,0.0017450092000919999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.8,0.002243494034940349
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.85,0.002883336183361837
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.9,0.0037212791127911246
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.95,0.004895659956599565
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.975,0.00584848725987261
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,19,quantile,0.99,0.007178782657826579
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.4,1.0842021724855044e-19
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.45,1.3738737387373882e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.5,3e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.55,4.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.6,5.999999999999997e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.65,7.941335913359153e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.7,0.001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.75,0.0012999999999999995
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.8,0.0016000000000000003
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.85,0.002079572495724956
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.9,0.0027926530265302636
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.95,0.0037852115021150103
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.975,0.004562283622836249
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,20,quantile,0.99,0.005520027460274606
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.25,2.5846808468084527e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.3,5.656482564825635e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.35,7.999999999999997e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.4,9.999999999999996e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.45,0.0011999999999999986
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.5,0.0013
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.55,0.0014999999999999996
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.6,0.0016911639116391128
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.65,0.0018999999999999996
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.7,0.0021637824378243757
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.75,0.0024999999999999996
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.8,0.0029552025520255196
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.85,0.003510215402154018
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.9,0.004203487934879354
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.95,0.005261368613686137
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.975,0.006161437139371444
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,21,quantile,0.99,0.00732756793567933
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.1,4.006010060100601e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.15,0.0010000000000000009
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.2,0.0014677588775887762
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.25,0.0018000000000000004
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.3,0.0020999999999999994
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.35,0.0023
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.4,0.002421804818048181
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.45,0.0026
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.5,0.0027
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.55,0.0028000000000000004
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.6,0.002999999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.65,0.0031000000000000003
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.7,0.0033021279212792085
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.75,0.0036
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.8,0.003942704027040272
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.85,0.0044
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.9,0.005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.95,0.005754348293482936
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.975,0.006462571775717751
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,22,quantile,0.99,0.0074
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.45,9.999999999999964e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.5,2e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.55,3.0000000000000024e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.6,4.000000000000004e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.65,6.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.7,8.000000000000003e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.75,0.0011
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.8,0.0014999999999999998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.85,0.0019000000000000002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.9,0.0025789407894078924
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.95,0.0038081702317023193
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.975,0.005073928314283138
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,23,quantile,0.99,0.005994131461314592
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.25,2.9999999999999987e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.3,6.000000000000006e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.35,9e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.4,0.0011
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.45,0.0013
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.5,0.0014000000000000002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.55,0.0016
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.6,0.0017776225762257637
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.65,0.002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.7,0.0023
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.75,0.002678529285292855
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.8,0.0031002602026020294
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.85,0.003674523795237949
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.9,0.004399999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.95,0.005309516995169948
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.975,0.006344560920609206
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,24,quantile,0.99,0.007533468354683556
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.3,1.8061770617706352e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.35,3.9002040020400533e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.4,5.900204002040058e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.45,7.900204002040044e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.5,9e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.55,0.0010900204002040046
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.6,0.0012900204002040043
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.65,0.0015050304003040047
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.7,0.0018784485844858484
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.75,0.0022871493714937178
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.8,0.0027706940069400707
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.85,0.0033900204002040046
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.9,0.004100243302433033
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.95,0.005102241272412724
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.975,0.00619037000370004
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,25,quantile,0.99,0.00752359045590456
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.4,1.6263032587282567e-19
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.45,1.5019185191851792e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.5,3e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.55,4.0000000000000013e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.6,6.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.65,8.300633006330029e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.7,0.0011238168381683808
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.75,0.0014844583445834496
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.8,0.0019203884038840424
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.85,0.0025
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.9,0.003176401464014643
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.95,0.004276406914069141
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.975,0.0052
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,26,quantile,0.99,0.006317440914409134
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.35,1.4406414064140627e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.4,4.203982039820387e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.45,6.203982039820391e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.5,8e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.55,9.956079060790583e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.6,0.0012203982039820393
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.65,0.0015193649436494355
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.7,0.0018203982039820383
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.75,0.002147425974259742
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.8,0.0025203982039820436
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.85,0.0030560731107311047
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.9,0.0037872379723797238
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.95,0.004938772537725426
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.975,0.006114504195041961
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,27,quantile,0.99,0.00752818251182511
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.25,1.8593460934609405e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.3,3.963352633526326e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.35,5.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.4,6.999999999999997e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.45,7.999999999999998e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.5,9e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.55,0.0010064090140901425
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.6,0.0011999999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.65,0.0013
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.7,0.0015
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.75,0.001766875418754185
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.8,0.0020999999999999994
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.85,0.0025251369513695095
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.9,0.003086218362183627
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.95,0.0037720912709127046
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.975,0.00435300115501155
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,28,quantile,0.99,0.005276393943939437
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.45,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.5,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.55,1.9999999999999996e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.6,4.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.65,6.999999999999999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.7,0.0010672055720557158
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.75,0.001599999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.8,0.0022185701857018584
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.85,0.0028709918599185975
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.9,0.003755009550095499
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.95,0.0049654046040460385
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.975,0.006136632616326206
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,30,quantile,0.99,0.007506329673296735
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.45,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.5,1e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.55,2.0000000000000025e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.6,3.999999999999999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.65,5.877860278602778e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.7,7.999999999999999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.75,0.0010999999999999998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.8,0.0014019706197061976
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.85,0.0018000000000000006
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.9,0.0023455640556405612
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.95,0.0032
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.975,0.00403471284712847
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,31,quantile,0.99,0.005050110661106602
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.45,9.999999999999996e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.5,2e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.55,3.6731987319874585e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.6,5.000000000000004e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.65,7.000000000000017e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.7,9.785278852788518e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.75,0.0012313160631606307
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.8,0.001600284002840029
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.85,0.0020506403064030634
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.9,0.002600000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.95,0.0033371051710517127
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.975,0.0040517040670406575
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,32,quantile,0.99,0.004975425204252034
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.4,6.580465804659645e-6
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.45,2.1199401994019952e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.5,4e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.55,6.415325153251532e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.6,8.909819098190982e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.65,0.001190981909819098
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.7,0.0014909819098190987
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.75,0.0018910531605316053
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.8,0.002422597425974258
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.85,0.0031096242462424605
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.9,0.004039811698116981
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.95,0.005299001140011402
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.975,0.006311923069230686
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,33,quantile,0.99,0.007728388893888944
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.2,1.0000000000000026e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.25,3.980597305973063e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.3,5.999999999999998e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.35,7.494612446124452e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.4,9e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.45,0.001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.5,0.0011
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.55,0.0012000000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.6,0.0013000000000000008
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.65,0.0014999999999999998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.7,0.0016581243812438093
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.75,0.0018999999999999998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.8,0.0021753167531675358
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.85,0.0025
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.9,0.003
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.95,0.00366738962389624
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.975,0.004173324183241831
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,34,quantile,0.99,0.0049106332463324555
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.45,1.3552527156068805e-19
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.5,2e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.55,4.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.6,7.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.65,0.0010999999999999996
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.7,0.001574044140441404
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.75,0.002122360723607237
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.8,0.0029000000000000015
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.85,0.0038108847088470883
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.9,0.005050069700697006
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.95,0.007522354573545723
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.975,0.009266227687276868
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,35,quantile,0.99,0.011059506075060739
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.25,1.0000000000000005e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.3,2.9999999999999965e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.35,4.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.4,5.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.45,6.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.5,7.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.55,8.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.6,9.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.65,0.0010000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.7,0.0012000000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.75,0.0014
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.8,0.001600000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.85,0.0019000000000000009
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.9,0.002344692946929472
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.95,0.0029999005490054884
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.975,0.003492753652536526
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,36,quantile,0.99,0.0041
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.2,1.9999999999999987e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.25,5.000000000000003e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.3,7.999999999999998e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.35,0.0010000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.4,0.0012000000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.45,0.0013999999999999998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.5,0.0015
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.55,0.0016627154771547716
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.6,0.0018000000000000002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.65,0.002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.7,0.002263035330353304
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.75,0.0025313720637206412
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.8,0.002917471374713755
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.85,0.003413573035730358
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.9,0.00407526475264753
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.95,0.005227359873598724
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.975,0.006207189821898193
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,37,quantile,0.99,0.007172724677246757
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.45,9.99999999999994e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.5,2.0000000000000004e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.55,3.999999999999994e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.6,5.999999999999994e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.65,8.439938399384003e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.7,0.001166765867658672
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.75,0.001501802768027679
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.8,0.0019986089860898597
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.85,0.002685061900618998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.9,0.003866660666606675
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.95,0.006064012840128397
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.975,0.0076705864308642575
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,38,quantile,0.99,0.009544042360423628
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.35,9.999999999999994e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.4,2.0000000000000096e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.45,3.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.5,4e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.55,5e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.6,6.18573385733857e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.65,7.999999999999997e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.7,9.107862078620783e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.75,0.0011712342123421206
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.8,0.0014542333423334184
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.85,0.001896742717427173
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.9,0.0023905183051830536
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.95,0.0030999999999999995
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.975,0.0037649761497614924
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,39,quantile,0.99,0.004489815108151078
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.45,1.26717267172674e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.5,3e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.55,4.912833128331287e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.6,6.502523025230242e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.65,8.999999999999998e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.7,0.001188976889768895
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.75,0.0015301193011930106
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.8,0.0019994637946379483
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.85,0.0025000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.9,0.0032033425334253396
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.95,0.004282151871518711
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.975,0.005100015275152751
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,40,quantile,0.99,0.006268583055830554
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.4,1.0000000000000026e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.45,2.0000000000000085e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.5,4e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.55,5.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.6,7.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.65,9.175086250862519e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.7,0.0012000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.75,0.0015000000000000007
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.8,0.0018769743697437057
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.85,0.002399999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.9,0.002986913669136692
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.95,0.0038
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.975,0.0046
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,41,quantile,0.99,0.005595915359153587
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.3,9.99999999999999e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.35,2.9999999999999976e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.4,3.999999999999999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.45,4.999999999999999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.5,6e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.55,6.999999999999999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.6,8.219444194441949e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.65,0.001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.7,0.0012045471454714507
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.75,0.0014999999999999992
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.8,0.0017999999999999995
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.85,0.0022819416694166888
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.9,0.0028605905059050575
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.95,0.0035156562565625657
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.975,0.00410428846788468
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,42,quantile,0.99,0.005049681056810546
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.2,1.335193351933455e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.25,3.682576825768255e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.3,6.000000000000004e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.35,8.209560095600961e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.4,0.001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.45,0.0011999999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.5,0.0013
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.55,0.0014905970559705598
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.6,0.0016
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.65,0.0018
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.7,0.002016333663336634
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.75,0.002340830908309084
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.8,0.0027554705547055444
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.85,0.0032636760867608646
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.9,0.003955299452994533
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.95,0.004811419564195642
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.975,0.005511953694536947
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,44,quantile,0.99,0.006585560555605552
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.05,4.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.1,0.0010784155841558419
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.15,0.0015000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.2,0.0018753495534955351
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.25,0.0021301513015130145
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.3,0.0023999999999999985
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.35,0.0025979508795087943
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.4,0.0027
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.45,0.0028999999999999994
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.5,0.003
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.55,0.003100000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.6,0.0033
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.65,0.0034223932239322383
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.7,0.003600000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.75,0.003873938739387392
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.8,0.004123847838478387
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.85,0.004496846718467186
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.9,0.004933618736187367
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.95,0.005612336773367734
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.975,0.006300000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,45,quantile,0.99,0.00717223718237182
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.45,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.5,7.32507325070875e-8
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.55,2.4527015270152933e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.6,4.4902499024990287e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.65,7.490249902499034e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.7,0.0011267995679956758
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.75,0.0014665174151741514
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.8,0.0019256909569095697
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.85,0.0024709290092900893
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.9,0.0031490249902499036
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.95,0.0041510134601346034
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.975,0.005049024990249902
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,46,quantile,0.99,0.00622732569325692
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.25,2.895028950287878e-6
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.3,2.970173701737002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.35,4.999999999999988e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.4,6.082324823248241e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.45,7.999999999999996e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.5,9e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.55,0.0010999999999999994
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.6,0.0012000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.65,0.0014000000000000002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.7,0.0016604288042880427
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.75,0.0019208157081570822
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.8,0.0022909133091330927
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.85,0.002635590305903055
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.9,0.0030999999999999995
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.95,0.0038999999999999985
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.975,0.004606199211992118
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,47,quantile,0.99,0.005508971849718493
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.1,4.992673926739276e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.15,0.001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.2,0.0013999999999999993
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.25,0.0017000000000000003
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.3,0.0019999999999999996
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.35,0.0022000000000000006
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.4,0.0024000000000000002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.45,0.0025999999999999986
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.5,0.0027
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.55,0.002800000000000002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.6,0.003
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.65,0.0031999999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.7,0.0034000000000000002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.75,0.0036999999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.8,0.004000000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.85,0.004400000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.9,0.004928626486264865
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.95,0.00571111626116261
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.975,0.006398037055370549
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,48,quantile,0.99,0.007282007260072577
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.45,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.5,1e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.55,2.958344583445836e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.6,5.259541595415946e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.65,8.309402594025959e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.7,0.0012291392913929078
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.75,0.0016958344583445832
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.8,0.0022155004550045623
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.85,0.0029564124641246223
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.9,0.003970172001720019
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.95,0.0057958344583445825
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.975,0.007288982789827911
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,49,quantile,0.99,0.009291516795167935
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.45,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.5,2e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.55,4.779516795167925e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.6,7e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.65,0.0010125550255502542
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.7,0.0014016879168791668
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.75,0.001946424464244644
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.8,0.0026172365723657236
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.85,0.003424567095670957
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.9,0.004439615896158968
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.95,0.006018348333483328
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.975,0.007514766647666471
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,50,quantile,0.99,0.009437989349893478
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.1,3.999999999999991e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.15,7.277250272502726e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.2,0.0010000000000000005
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.25,0.0012861496114961153
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.3,0.0014966156661566626
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.35,0.001600000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.4,0.0017999999999999997
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.45,0.0019
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.5,0.002
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.55,0.0021000000000000003
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.6,0.0022000000000000006
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.65,0.002399999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.7,0.002513831238312373
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.75,0.0027471257212572124
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.8,0.0029999999999999996
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.85,0.0032801163511635045
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.9,0.003616966969669697
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.95,0.004229622596225964
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.975,0.004754256367563673
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,51,quantile,0.99,0.0053400429604296045
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.25,5.4453294532945276e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.3,3.4749217492174915e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.35,6.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.4,8.000000000000003e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.45,0.001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.5,0.0011
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.55,0.001299999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.6,0.0014220476204762007
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.65,0.0016999999999999995
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.7,0.001999999999999999
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.75,0.002301977269772699
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.8,0.002709821098210984
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.85,0.0033442339923399245
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.9,0.0041
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.95,0.005530622206222063
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.975,0.006632904354043514
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,53,quantile,0.99,0.007730406484064832
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.35,2.1527555275552488e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.4,5.999999999999998e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.45,8.564175641756419e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.5,0.0011
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.55,0.0013667724677246772
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.6,0.0017000000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.65,0.002176876918769189
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.7,0.002742972929729298
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.75,0.003355783807838077
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.8,0.004053567935679351
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.85,0.0049582570825708345
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.9,0.006271979519795184
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.95,0.008202846028460279
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.975,0.01005829985799866
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,54,quantile,0.99,0.012635582085820864
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.45,9.999999999999996e-5
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.5,2e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.55,3.0000000000000014e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.6,5.000000000000001e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.65,7.000000000000002e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.7,9.124313243132449e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.75,0.0012282097820978223
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.8,0.0016
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.85,0.002032522225222254
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.9,0.002561431414314144
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.95,0.003212734377343768
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.975,0.003920099900999013
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,55,quantile,0.99,0.0048372993529935205
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.15,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.2,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.25,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.3,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.35,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.4,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.45,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.5,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.55,2.0000000000000052e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.6,4.828706287062854e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.65,8.350833508335085e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.7,0.0013
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.75,0.0019723487234872337
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.8,0.002653645936459374
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.85,0.003706637116371165
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.9,0.004945311853118518
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.95,0.007075930309303084
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.975,0.009061396063960576
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,56,quantile,0.99,0.011693027120271206
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.01,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.025,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.05,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.1,0
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.15,2.999999999999999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.2,5.629726297262979e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.25,7.999999999999999e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.3,9.999999999999996e-4
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.35,0.0011000000000000007
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.4,0.0012999999999999995
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.45,0.0014
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.5,0.0015
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.55,0.0016
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.6,0.0017000000000000012
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.65,0.0018999999999999998
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.7,0.002001857318573185
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.75,0.002200000000000001
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.8,0.0024592873928739323
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.85,0.0027
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.9,0.003067489374893744
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.95,0.0035999999999999986
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.975,0.00409317493174932
+2025-11-22,3,wk inc rsv prop ed visits,2025-12-13,US,quantile,0.99,0.00467172937729377


### PR DESCRIPTION
This PR:

* [x] Adds the baseline forecast for 2025-11-22, which failed last week, using the refactored `generate_hub_baseline` function (which now has an `as_of` date parameter).

The script used for this file is as follows: 


```r
#' Generates the baseline forecast for reference date 2025-11-22
#' using vintaged data as of 2025-11-19.

devtools::load_all("hubhelpr")


base_hub_path <- "rsv-forecast-hub"
reference_date <- as.Date("2025-11-22")
disease <- "rsv"
as_of <- "2025-11-19"

generate_hub_baseline(
  base_hub_path = base_hub_path,
  reference_date = reference_date,
  disease = disease,
  as_of = as_of
)

```