### PR TITLE
Update Code Owners File To Align With Other STF Hub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,9 @@
 
-/src/* @sbidari @dylanhmorris @O957
 /.github/** @sbidari @dylanhmorris @O957
 /hub-config/* @sbidari @dylanhmorris @O957
 /auxiliary_data/weekly-model-submissions/ @sbidari @dylanhmorris @O957
 /model-output/RSVHub-baseline/ @sbidari @dylanhmorris @O957
 /model-output/RSVHub-ensemble/ @sbidari @dylanhmorris @O957
-README.md @sbidari @dylanhmorris @O957
+**/README.md @sbidari @dylanhmorris @O957
 .pre-commit-config.yaml @sbidari @dylanhmorris @O957
 .gitignore @sbidari @dylanhmorris @O957


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file of this repository to align with the version in the `covid19-forecast-hub` <https://github.com/CDCgov/covid19-forecast-hub/blob/main/.github/CODEOWNERS>. Decision-making regarding the contents of this file primarily occurred in this PR: <https://github.com/CDCgov/covid19-forecast-hub/pull/674> (amazing that it feels so much more recent that this occurred). 