### PR TITLE
add internal reports dispatch

### DIFF
--- a/.github/workflows/dispatch-ensemble-addition.yaml
+++ b/.github/workflows/dispatch-ensemble-addition.yaml
@@ -3,11 +3,11 @@ name: "Send Dispatch after ensemble addition"
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - main
     paths:
       - 'model-output/RSVHub-ensemble/*'
-    
+
 jobs:
   dispatch-webpage-update:
     if: ${{ github.repository_owner == 'CDCgov' }}
@@ -19,8 +19,8 @@ jobs:
         with:
           app-id: ${{ vars.ENT_GH_APP_ID }}
           private-key: ${{ secrets.ENT_GH_APP_KEY }}
-          owner: cdcent  
-          repositories: cfa-forecast-hub-internal-reports  
+          owner: cdcent
+          repositories: cfa-forecast-hub-internal-reports
 
       - name: "Repository Dispatch"
         uses: peter-evans/repository-dispatch@v4

--- a/.github/workflows/dispatch-target-data-update.yaml
+++ b/.github/workflows/dispatch-target-data-update.yaml
@@ -3,11 +3,11 @@ name: "Send a dispatch after target data update"
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - main
     paths:
       - 'target-data/*'
-    
+
 jobs:
   update-visualization-data:
     if: ${{ github.repository_owner == 'CDCgov' }}
@@ -19,8 +19,8 @@ jobs:
         with:
           app-id: ${{ vars.ENT_GH_APP_ID }}
           private-key: ${{ secrets.ENT_GH_APP_KEY }}
-          owner: cdcent  
-          repositories: cfa-forecast-hub-internal-reports  
+          owner: cdcent
+          repositories: cfa-forecast-hub-internal-reports
 
       - name: "Repository Dispatch"
         uses: peter-evans/repository-dispatch@v4


### PR DESCRIPTION
Facilitates auto scoring of RSVHub and internal webage update. Mirrors the setup in https://github.com/CDCgov/covid19-forecast-hub/pull/1252
