### PR TITLE
Update Target Data One Hour Later

### DIFF
--- a/.github/workflows/update-target-data.yaml
+++ b/.github/workflows/update-target-data.yaml
@@ -9,7 +9,7 @@ on:
         default: false
 
   schedule:
-    - cron: "00 16 * * 3" # run every Wednesday at 4:00 PM UTC (12:00 PM EST)
+    - cron: "00 17 * * 3" # run every Wednesday at 5:00 PM UTC (1:00 PM EST)
 
 jobs:
   update-target-data:


### PR DESCRIPTION
This PR changes the time target data is updated, given delays from NHSN.