### PR TITLE
Update Hub Webpage And Data Dispatching Names

### DIFF
--- a/.github/workflows/dispatch-ensemble-addition.yaml
+++ b/.github/workflows/dispatch-ensemble-addition.yaml
@@ -28,4 +28,3 @@ jobs:
           token: ${{ steps.get_token_ent.outputs.token }}
           repository: cdcent/cfa-forecast-hub-internal-reports
           event-type: rsv-ensemble-added
-


### PR DESCRIPTION
This PR syncs the naming of the dispatch types with `cfa-forecast-hub-reports` (see <https://github.com/CDCgov/cfa-forecast-hub-reports/pull/92>). Also, the visualization data dispatch had been added here following <https://github.com/CDCgov/covid19-forecast-hub/blob/main/.github/workflows/dispatch-ensemble-addition.yaml>.