### PR TITLE
Synchronize App-IDs and App-Keys Across Hubs

### DIFF
--- a/.github/workflows/auto-merge-authorized-prs.yaml
+++ b/.github/workflows/auto-merge-authorized-prs.yaml
@@ -50,8 +50,8 @@ jobs:
         id: get_token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CDCGOV_HUB_BOT_APP_ID }}
-          private-key: ${{ secrets.CDCGOV_HUB_BOT_APP_KEY }}
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
 
       - name: "Approve PR"
         env:

--- a/.github/workflows/create-baseline.yaml
+++ b/.github/workflows/create-baseline.yaml
@@ -26,8 +26,8 @@ jobs:
       id: get_token
       uses: actions/create-github-app-token@v2
       with:
-        app-id: ${{ vars.CDCGOV_HUB_BOT_APP_ID }}
-        private-key: ${{ secrets.CDCGOV_HUB_BOT_APP_KEY }}
+        app-id: ${{ vars.GH_APP_ID }}
+        private-key: ${{ secrets.GH_APP_KEY }}
 
     - name: "Checkout Code"
       uses: actions/checkout@v6

--- a/.github/workflows/create-ensemble.yaml
+++ b/.github/workflows/create-ensemble.yaml
@@ -26,8 +26,8 @@ jobs:
       id: get_token
       uses: actions/create-github-app-token@v2
       with:
-        app-id: ${{ vars.CDCGOV_HUB_BOT_APP_ID }}
-        private-key: ${{ secrets.CDCGOV_HUB_BOT_APP_KEY }}
+        app-id: ${{ vars.GH_APP_ID }}
+        private-key: ${{ secrets.GH_APP_KEY }}
 
     - name: "Checkout Code"
       uses: actions/checkout@v6

--- a/.github/workflows/dispatch-ensemble-addition.yaml
+++ b/.github/workflows/dispatch-ensemble-addition.yaml
@@ -37,8 +37,8 @@ jobs:
         id: get_token_gov
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CDCGOV_HUB_BOT_APP_ID }}
-          private-key: ${{ secrets.CDCGOV_HUB_BOT_APP_KEY }}
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_KEY }}
           owner: CDCgov
           repositories: cfa-forecast-hub-reports
 

--- a/.github/workflows/update-target-data.yaml
+++ b/.github/workflows/update-target-data.yaml
@@ -21,8 +21,8 @@ jobs:
       id: get_token
       uses: actions/create-github-app-token@v2
       with:
-        app-id: ${{ vars.CDCGOV_HUB_BOT_APP_ID }}
-        private-key: ${{ secrets.CDCGOV_HUB_BOT_APP_KEY }}
+        app-id: ${{ vars.GH_APP_ID }}
+        private-key: ${{ secrets.GH_APP_KEY }}
 
     - name: "Checkout Code"
       uses: actions/checkout@v6


### PR DESCRIPTION
This PR synchronizes the app ID and keys across `covid19-forecast-hub` and `rsv-forecast-hub`. This is a draft right now since while I have made the Variable necessary, I have not yet create the Secret.