### PR TITLE
Include client-payload to the intended job 

### DIFF
--- a/.github/workflows/dispatch-ensemble-addition.yaml
+++ b/.github/workflows/dispatch-ensemble-addition.yaml
@@ -28,7 +28,6 @@ jobs:
           token: ${{ steps.get_token_ent.outputs.token }}
           repository: cdcent/cfa-forecast-hub-internal-reports
           event-type: rsv-ensemble-added
-          client-payload: '{"disease":"rsv"}'
 
   dispatch-visualization-data:
     if: ${{ github.repository_owner == 'CDCgov' }}
@@ -49,3 +48,4 @@ jobs:
           token: ${{ steps.get_token_gov.outputs.token }}
           repository: CDCgov/cfa-forecast-hub-reports
           event-type: rsv-ensemble-added
+          client-payload: '{"disease":"rsv"}'


### PR DESCRIPTION
Added client-payload was sending disease to internal-reports-repo instead of cfa-forecast-report

https://github.com/CDCgov/cfa-forecast-hub-reports/actions/runs/24514963539/job/71656200399