### PR TITLE
Add RespiLens developers to `hub_developers.json`

### DIFF
--- a/auxiliary-data/hub_developers.json
+++ b/auxiliary-data/hub_developers.json
@@ -10,5 +10,17 @@
     "organization": "CDC",
     "url": "https://github.com/CDCgov/cfa-forecast-hub-reports",
     "description": "Weekly summarized RSVHub data"
+  },
+  {
+    "name": "RespiLens",
+    "designated_contacts": [
+      {
+        "contact_name": "Emily Przykucki",
+        "contact_email": "emily.przykucki@gmail.com"
+      }
+    ],
+    "organization": "ACCIDDA",
+    "url": "https://github.com/ACCIDDA/RespiLens",
+    "description": "RespiLens is a responsive web app to visualize respiratory disease forecasts in the US, focused on accessibility for state health departments and the general public."
   }
 ]

--- a/auxiliary-data/hub_developers.json
+++ b/auxiliary-data/hub_developers.json
@@ -17,6 +17,10 @@
       {
         "contact_name": "Emily Przykucki",
         "contact_email": "emily.przykucki@gmail.com"
+      },
+      {
+        "contact_name": "Joseph Lemaitre",
+        "contact_email": "jo.lemaitresamra@gmail.com"
       }
     ],
     "organization": "ACCIDDA",


### PR DESCRIPTION
Added @jcblemai and I as developers that use the rsv-forecast-hub.